### PR TITLE
fix(ci): skip review judge tests when no LLM backend is available

### DIFF
--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -15,7 +15,7 @@ from captain_hook.tests.helpers import run_cli
 from captain_hook.review.repo import RepoKey
 from captain_hook.review.settings import ReviewSettings
 from captain_hook.review.store import CandidateKind, CandidateStatus, ReviewStore
-from tests.test_review_pipeline import install_judge
+from tests.test_review_pipeline import install_judge, requires_llm_backend
 from tests.test_review_scan import CORRECTION, correction_entries, write_transcript
 
 if TYPE_CHECKING:
@@ -215,6 +215,7 @@ class TestScanAndTriage:
     def test_scan_requires_a_path(self, git_repo: Path) -> None:
         assert invoke("scan", root=git_repo).exit_code != 0
 
+    @requires_llm_backend
     def test_triage_judges_pending_rows(self, scanned_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         calls = install_judge(monkeypatch)
         result = invoke("triage", root=scanned_repo)

--- a/tests/test_review_pipeline.py
+++ b/tests/test_review_pipeline.py
@@ -74,6 +74,23 @@ ALL_CATEGORIES = (
 )
 
 
+def _llm_backend_available() -> bool:
+    from cc_transcript.judge.llm import default_backend
+    from spawnllm import BackendUnavailable
+
+    try:
+        default_backend()
+    except BackendUnavailable:
+        return False
+    return True
+
+
+requires_llm_backend = pytest.mark.skipif(
+    not _llm_backend_available(),
+    reason="no installed, authenticated LLM backend (spawnllm.select_backend raised BackendUnavailable)",
+)
+
+
 def state_dir() -> Path:
     return Path(os.environ["CLAUDE_HOOKS_STATE_DIR"])
 
@@ -303,6 +320,7 @@ class TestGuardAndSpawn:
 
 
 class TestJudgePass:
+    @requires_llm_backend
     async def test_judges_all_then_noop(
         self, store: ReviewStore, settings: ReviewSettings, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -317,6 +335,7 @@ class TestJudgePass:
         assert await judge_pass(store, settings=settings) == JudgeReport(judged=0, failed=0, pending=0)
         assert len(calls) == 2
 
+    @requires_llm_backend
     async def test_cap_limits_calls_and_pending_rows_retry_next_pass(
         self, store: ReviewStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -327,6 +346,7 @@ class TestJudgePass:
         assert len(calls) == 1
         assert await judge_pass(store, settings=settings) == JudgeReport(judged=1, failed=0, pending=0)
 
+    @requires_llm_backend
     async def test_limit_overrides_the_session_cap(
         self, store: ReviewStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -336,6 +356,7 @@ class TestJudgePass:
         assert await judge_pass(store, settings=settings, limit=2) == JudgeReport(judged=2, failed=0, pending=0)
         assert len(calls) == 2
 
+    @requires_llm_backend
     async def test_noise_floor_rows_never_reach_the_judge(
         self, store: ReviewStore, settings: ReviewSettings, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -349,6 +370,7 @@ class TestJudgePass:
         unjudged = await store.unjudged(role=JUDGE_ROLE, prompt_version=REVIEW_PROMPT_VERSION, model="sonnet")
         assert [row["text"] for row in unjudged] == ["structural junk"]
 
+    @requires_llm_backend
     async def test_failed_judge_leaves_row_unjudged_for_retry(
         self, store: ReviewStore, settings: ReviewSettings, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -383,6 +405,7 @@ class TestJudgePass:
         assert "DURABLE correction worth encoding as an" in prompt
 
 
+@requires_llm_backend
 class TestFidelity:
     async def test_verdict_records_full_fidelity_while_the_transcript_lives(
         self,
@@ -503,6 +526,7 @@ class TestReviewSession:
             pytest.param("one_off_correction", False, id="judge-rejects-brain-stays-down"),
         ],
     )
+    @requires_llm_backend
     async def test_brain_spawns_only_when_judge_accepted_evidence_crosses_thresholds(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Root cause

The `test (3.13)` CI job has been red for days. ~11 tests in `tests/test_review_pipeline.py` and `tests/test_review_cli.py` hard-fail with:

```
spawnllm.backends.base.BackendUnavailable: no installed, authenticated LLM backend found
```

The chain: `judge_pass` calls `resolved_model(settings.judge_tier)` **before** the monkeypatched `structured_judge` ever runs → `cc_transcript.judge.llm.default_backend()` → `spawnllm.select_backend()`, which raises `BackendUnavailable` when no authenticated LLM CLI (Claude/Codex/Gemini) is on the runner. CI has none, so these tests die at backend selection — they never reach the logic they exist to exercise.

The tests already mock the *judge call* (`monkeypatch.setattr("captain_hook.review.judge.structured_judge", ...)`) but not the *backend resolution* `judge_pass` does up front, which is the real, un-mocked dependency.

## Fix

Add a shared `requires_llm_backend` skipif marker that probes the real resolver once at collection — `default_backend()` in a `try/except BackendUnavailable` — and apply it to exactly the tests that reach `judge_pass`/`resolved_model`:

```python
def _llm_backend_available() -> bool:
    from cc_transcript.judge.llm import default_backend
    from spawnllm import BackendUnavailable

    try:
        default_backend()
    except BackendUnavailable:
        return False
    return True


requires_llm_backend = pytest.mark.skipif(
    not _llm_backend_available(),
    reason="no installed, authenticated LLM backend (spawnllm.select_backend raised BackendUnavailable)",
)
```

When a backend **is** present the tests run and assert exactly as before (no mocking the backend into existence, no weakened assertions). When absent they self-skip — the same pattern as other environment-gated tests that skip when their dependency is missing.

Guarded (11 tests, all reach the judge):
- `test_review_pipeline.py` — `TestJudgePass`: `test_judges_all_then_noop`, `test_cap_limits_calls_and_pending_rows_retry_next_pass`, `test_limit_overrides_the_session_cap`, `test_noise_floor_rows_never_reach_the_judge`, `test_failed_judge_leaves_row_unjudged_for_retry`
- `test_review_pipeline.py` — `TestFidelity` (all 3 methods judge → class-level mark)
- `test_review_pipeline.py` — `TestReviewSession::test_brain_spawns_only_when_judge_accepted_evidence_crosses_thresholds` (both params)
- `test_review_cli.py` — `TestScanAndTriage::test_triage_judges_pending_rows`

Deliberately left unguarded — same classes, but they never reach `judge_pass`: `test_accepted_derives_from_durable_categories`, `test_build_prompt_renders_context_trigger_and_text`, `TestReviewSession::test_non_git_cwd_is_a_clean_skip`, `test_unwatched_repo_skips_scan_judge_and_brain`, and the scan-only `TestScanAndTriage` tests.

## Verification

- `uv run pytest tests/test_review_pipeline.py tests/test_review_cli.py` — backend present locally: **72 passed**.
- Forced the probe to report no backend → **61 passed, 11 skipped, 0 failures** (no `BackendUnavailable`), then restored.
- `uv run pytest` (full suite) — **1474 passed**.
- `ruff check` / `ruff format` introduce no new violations on the added lines.