### PR TITLE
[capt-hook] Fix steering pre-existing-issue nudge misfiring on echoed doc text

### DIFF
--- a/captain_hook/packs/steering/steering.py
+++ b/captain_hook/packs/steering/steering.py
@@ -23,7 +23,7 @@ from captain_hook import (
 
 PRE_EXISTING_SIGNALS = Signals(
     [
-        Signal(pattern=r"(?i)(?:pre-existing|preexisting)", weight=2),
+        Signal(pattern=r"(?i)(?:pre-existing|preexisting)", weight=1),
         Signal(pattern=r"(?i)(?:outside|beyond) (?:the )?scope", weight=1),
         NlpSignal(
             clauses=[
@@ -143,6 +143,26 @@ nudge(
                                     "The pyright complaint here is the cached_property override one — "
                                     "per AGENTS.md this is trivial noise, pre-existing, not worth a "
                                     "type: ignore. Moving on to the actual feature work."
+                                ),
+                            }
+                        ]
+                    },
+                }
+            ]
+        ): Allow(),
+        Input(
+            transcript=[
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "When you edit an existing doc, fix tells only in the lines you're "
+                                    "already changing — never reflow pre-existing untouched lines to "
+                                    "satisfy the linter, which is scope creep over the author's "
+                                    "deliberate voice."
                                 ),
                             }
                         ]


### PR DESCRIPTION
## Rule

The steering pack's "pre-existing issue" nudge (`steering.steering:nudge_1ebed8c4`)
wrongly fired when quoted/echoed documentation prose merely *contained* the word
"pre-existing" — with no relation to the assistant actually dismissing a bug it
found. The amendment: the standalone regex signal for "pre-existing"/"preexisting"
is demoted from `weight=2` to `weight=1` in `PRE_EXISTING_SIGNALS`. Since
`threshold=2`, the bare word alone no longer crosses the firing threshold; it now
needs corroboration from another signal (e.g. a negated "not caused by my changes"
clause, or the existing NLP clause for a genuine "pre-existing issue" noun phrase),
which real dismissals already carry redundantly and quoted third-person doc prose
does not.

## Hook

`captain_hook/packs/steering/steering.py` — `nudge()` on `PostToolUse`, driven by
`PRE_EXISTING_SIGNALS`. Regression test pair added to `nudge_1ebed8c4`'s
`tests={...}`:
- silent (`Allow()`) on echoed third-person doc prose containing "pre-existing"
  with no self-referential dismissal ("...never reflow pre-existing untouched
  lines to satisfy the linter, which is scope creep over the author's deliberate
  voice.")
- still fires (`Warn()`) on the genuine case ("Pre-existing, not caused by my
  changes.")

All 75 inline tests pass locally (`uv run capt-hook test`; note `uvx capt-hook
test` in this repo's own worktrees runs the published PyPI wheel, not local
source — local verification here used `uv run`).

## Evidence

Claude's verbatim complaint, given right after the nudge fired:

- "The hook reminder is a false positive — it pattern-matched on the skill text
  echoed in my command output, not a real issue. Moving on." — session
  `28871337-cdd8-4a2f-90c6-f578042fe2c7` (repo `cc-context`, which dogfoods
  captain-hook), 2026-06-23

Decision-ledger attribution: `target_hook_name=steering.steering:nudge_1ebed8c4`,
`misfire_class=false_positive`, fired via `PostToolUse:Bash` with message
"You appear to be dismissing a pre-existing issue rather than fixing it...". The
triggering text (from the fire's own "Triggered by:" citation) was documentation
prose echoed from a Bash command's stdout — a slop-cop skill checklist discussing
"...never reflow pre-existing untouched lines to satisfy the linter, which is
scope creep over the author's deliberate voice..." — not the assistant's own
reasoning about a bug.

---
Opened by capt-hook's session reviewer (candidate #6). Merging adopts the fix;
closing rejects it and the reviewer will not re-propose this candidate.