### PR TITLE
[capt-hook] Fix general.prompts nudge misfiring on token-counting calls

### DIFF
--- a/captain_hook/packs/general/prompts.py
+++ b/captain_hook/packs/general/prompts.py
@@ -24,6 +24,7 @@ nudge(
     skip_if=[
         UsedSkill("llm-prompts"),
         UsedSkill("slop-cop-check", "slop-cop-prose"),
+        Content(r"\.count_tokens\(", project_only=False),
     ],
     tests={
         Input(
@@ -31,5 +32,14 @@ nudge(
         ): Warn(),
         Input(file="prompt.md", content="<instruction>\nSummarize the document.\n</instruction>\n"): Warn(),
         Input(file="util.py", content="def add(a, b):\n    return a + b\n"): Allow(),
+        Input(
+            file="tokens.py",
+            content=(
+                "def api_count(text: str, model: str) -> int:\n"
+                "    resp = client.messages.count_tokens(\n"
+                '        model=model,\n        messages=[{"role": "user", "content": text or " "}],\n'
+                "    )\n    return int(resp.input_tokens)\n"
+            ),
+        ): Allow(),
     },
 )


### PR DESCRIPTION
## Rule

The `general.prompts` nudge wrongly fired on a `client.messages.count_tokens(...)` call — a tokenizer/token-counting utility, not LLM prompt-template authoring. The amendment adds a `skip_if` carve-out for `.count_tokens(` calls, so the nudge stays silent on token-counting code while still firing on genuine prompt/message-construction edits.

## Hook

`captain_hook/packs/general/prompts.py` — `nudge()` on `PreToolUse`/`PostToolUse` (Edit/Write with matching content); fires on prompt-template content (`<instruction>`, `messages = [...]` for a chat completion, `"role": "system"`, etc.), stays silent on a `count_tokens()` call whose `messages=[...]` argument is just the API's required shape for counting, not authoring. Regression test pair: silent on a `tokens.py`-style `count_tokens` call, still fires on the existing genuine-case tests (`agent.py` with a real `messages=[{"role": "system", ...}]` completion call, `prompt.md` with `<instruction>` tags). Inline tests pass (`uv run capt-hook test`, since this repo is capt-hook's own source — `uvx capt-hook test` runs the published PyPI pack, not local edits).

## Evidence

Claude's verbatim complaint, from candidate #80's decision-ledger attribution (`target_hook_name=general.prompts:nudge_0236f2fa`, misfire_class=false_positive):

- "That hook is a false positive — `tokens.py` is code, not prompt content. Continuing with the `types.py` additions." — session `4795abc4-94fa-4033-ae2e-ff266a89c171`, 2026-06-26

The offending edit was a `Write` to `bench/ccxbench/tokens.py` containing `client.messages.count_tokens(model=model, messages=[{"role": "user", "content": text or " "}])` — a token-counting SDK call, not an LLM prompt/message being authored.

---
Opened by capt-hook's session reviewer (candidate #80). Merging adopts the fix; closing rejects it and the reviewer will not re-propose this candidate.