### PR TITLE
[capt-hook] Fix general.tasks nudge misfiring on task-notification prompts

### DIFF
--- a/captain_hook/packs/general/tasks.py
+++ b/captain_hook/packs/general/tasks.py
@@ -55,6 +55,13 @@ class DriftedFromTasks(CustomCondition):
         return since.tool_calls.named("Bash|Grep|Glob|WebSearch|WebFetch|LSP|Skill").count() >= TASK_DRIFT_THRESHOLD
 
 
+class TaskNotification(CustomCondition):
+    """Matches when the prompt is a system-injected background-task report, not free-form user text."""
+
+    def check(self, evt: BaseHookEvent) -> bool:
+        return (evt.user_prompt or "").strip().startswith("<task-notification>")
+
+
 gate(
     "Open tasks remain. Before stopping, mark each finished task status='completed' via the "
     "TaskUpdate tool (add a note if you're deliberately deferring one), or output "
@@ -120,7 +127,7 @@ nudge(
 nudge(
     "This message has several distinct requests. Use the TaskCreate tool for each item "
     "before starting work, so none gets dropped. See: CLAUDE.md § Task Tracking.",
-    skip_if=[InPlanMode()],
+    skip_if=[InPlanMode(), TaskNotification()],
     events=Event.UserPromptSubmit,
     signals=Signals(
         [
@@ -141,5 +148,12 @@ nudge(
         Input(prompt="1. add foo\n2. fix bar\n3. update baz"): Warn(),
         Input(prompt="just fix the typo"): Allow(),
         Input(prompt="1. add foo\n2. fix bar\n3. update baz", permission_mode="plan"): Allow(),
+        Input(
+            prompt=(
+                "<task-notification>\n<task-id>abc</task-id>\n<status>completed</status>\n"
+                "<summary>Agent finished</summary>\n<result>\n- `cc-transcript` -> version 7.0.1\n"
+                "- `spawnllm` -> version 0.5.2\n</result>\n</task-notification>"
+            )
+        ): Allow(),
     },
 )


### PR DESCRIPTION
## Rule

The "several distinct requests" nudge on `UserPromptSubmit` wrongly fired on `<task-notification>` messages — system-injected background-agent completion reports, not free-form human text. Its bullet/numbered-list signals naturally match a multi-item status report (e.g. a list of bumped package versions). The amendment adds a `TaskNotification` condition (mirroring the same `<task-notification>` prefix check `captain_hook/classifiers/conductor.py` already uses to exclude system-injected text from user-authored classification) to `skip_if`, so the nudge stays silent on task-notifications while still firing on genuine multi-item human requests.

## Hook

`captain_hook/packs/general/tasks.py` — `nudge()` on `UserPromptSubmit`, signal-scored (bulleted/numbered lists, "also"/"additionally", repeated imperatives); fires when a human prompt bundles several distinct asks, stays silent on a `<task-notification>` background-task report. Regression test pair: silent on a `<task-notification>` prompt containing a bulleted version-bump list, still fires on the existing genuine-case test (`"1. add foo\n2. fix bar\n3. update baz"`). Inline tests pass (`uv run capt-hook test`, since this repo is capt-hook's own source — `uvx capt-hook test` runs the published PyPI pack, not local edits).

## Evidence

Claude's verbatim complaint, from candidate #71's decision-ledger attribution (`target_hook_name=general.tasks:nudge_9cf8ea99`, misfire_class=misfire):

- "cc-pushback reports **GREEN** — 158 passed, lock pins cc-transcript 7.0.1 + spawnllm 0.5.2, clean one-line diff. (The hook nudge about \"several requests\" misfires on a task-notification — my task list already covers this; nothing to add.)" — session `7489678f-4a07-4d87-82d2-ba71b406ba5a`, 2026-06-25

The triggering event was a `<task-notification>` reporting a finished subagent's release-prep summary, which contained a two-item bulleted list of locked package versions (`- cc-transcript ... - spawnllm ...`) — enough to cross the signal threshold despite carrying no distinct human requests at all.

---
Opened by capt-hook's session reviewer (candidate #71). Merging adopts the fix; closing rejects it and the reviewer will not re-propose this candidate.