### PR TITLE
[capt-hook] Fix pre-existing-issue nudge misfiring on flagged (not dismissed) risk

### DIFF
--- a/captain_hook/packs/steering/steering.py
+++ b/captain_hook/packs/steering/steering.py
@@ -57,7 +57,9 @@ nudge(
             Signal(pattern=r"(?i)(?<!no change )(?<!no changes )(?:outside|beyond) (?:the )?scope", weight=1),
             NlpSignal(
                 clauses=[
-                    Clause(noun=Phrase.expand("change"), verb=Phrase("cause", "introduce"), negated=True),
+                    Clause(
+                        noun=Phrase.expand("change"), verb=Phrase("cause", "introduce"), negated=True, tense="completed"
+                    ),
                     Clause(
                         noun=Phrase("issue", "bug", "problem", "error", "failure", "violation", "warning"),
                         verb=Phrase("leave"),
@@ -429,6 +431,25 @@ nudge(
                                 "text": (
                                     "Landed the parser fix; I left the pre-existing lint warnings alone since they "
                                     "predate this change, and all 42 tests pass."
+                                ),
+                            }
+                        ]
+                    },
+                }
+            ]
+        ): Allow(),
+        # cand6-g2 (session c2b980ad, 2026-07-08): flagged risk, not a dismissal.
+        Input(
+            transcript=[
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "cc-pool might not be compatible with those API changes, or they could "
+                                    "introduce unexpected behavior shifts beyond what my fix addresses."
                                 ),
                             }
                         ]


### PR DESCRIPTION
## Rule
steering.steering:nudge_1ebed8c4 (candidate #6, generation 2 — reopened after PR #3's merge). The negated change-cause/introduce NlpSignal clause matched "might not be compatible ... could introduce unexpected behavior" as a dismissal, because the unrelated negation ("not compatible") sat within 3 dependency hops of the clause's noun anchor. Fix: require the negated verb itself be past-tense (`tense="completed"`), so only completed-action claims like "not caused by my changes" count.

## Evidence
Judge-confirmed misfire, session `c2b980ad-8b36-490b-9f82-a63733eefb43` (repo claude-pool), 2026-07-08: "Dep bump clean — fusekit v0.34.0, both builds green (the hook is misfiring on my earlier hypothesizing; the bump verified fine and pulls in only my reviewed fix + 2 benign commits)."

Two other post-merge observations on this candidate (sessions 0cf24e19-…, 2026-07-02, and 5b8a5715-…, 2026-07-10) no longer reproduce under current `main` — already fixed by d1593ed6/21dbe3f5. Only the case above still fired; regression test added.

## Verify
`uvx --isolated capt-hook test` — 258 passed, 1 pre-existing unrelated failure (`general.docs:llm_gate_b4e3044c`, present on `origin/main` before this change, not touched here).

---
Opened by capt-hook's session reviewer (candidate #6).