### PR TITLE
[capt-hook] Sweep bootstrap/template fixes across instantiated repos

### DIFF
--- a/captain_hook/packs/general/bootstrap.py
+++ b/captain_hook/packs/general/bootstrap.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from captain_hook import FilePath, TestFile, Tool, llm_nudge
+
+# Path glob over-selects on "template"/"bootstrap" (including false positives like
+# Bootstrap-CSS); the LLM judge is the real filter.
+llm_nudge(
+    "You are checking whether a file edit needs to propagate beyond this one repo. "
+    "The edited file's before/after text is in <before_edit>/<after_edit>. Judge only "
+    "whether the edited file (its path and content) is plausibly a CANONICAL script, "
+    "config, or workflow template that other repos are instantiated or synced FROM -- a "
+    "bootstrap/scaffold template, a fleet-distributed installer or CI script, or similar "
+    "'this seeds copies elsewhere' artifact -- as opposed to an ordinary repo-local file "
+    "with no other consumers (this also covers unrelated files that merely contain the "
+    "word 'bootstrap', e.g. a Bootstrap-CSS asset -- those are never canonical sources). "
+    "If it plausibly IS such a canonical/template source, set fire=true only when the "
+    "edit itself gives no sign the agent already considered propagating the fix to repos "
+    "already bootstrapped/instantiated from it (no mention of a sweep, sync, or fleet "
+    "update). Otherwise set fire=false.",
+    message=lambda r: (
+        "User feedback (2026-07-08, session 9e5a15d4): \"1, but make the change in the "
+        "templaet script and across all bootstrapepd repo as well where relevant\". "
+        f"{r.reasoning} Fix the canonical template here, then sweep the same fix across "
+        "already-bootstrapped/instantiated repos where relevant, not just this one."
+    ),
+    only_if=[
+        Tool("Write|Edit"),
+        FilePath("**/*template*", "**/*bootstrap*", "**/templates/**", "**/scaffold*/**"),
+    ],
+    skip_if=[TestFile()],
+    max_fires=3,
+)


### PR DESCRIPTION
## Rule

When a fix touches a canonical bootstrap/template file (a script, config, or workflow other repos are instantiated or synced from), make the fix in the canonical template and sweep it across already-bootstrapped/instantiated repos where relevant — not just the one repo you happen to be in.

## Hook

`captain_hook/packs/general/bootstrap.py` — `llm_nudge` on `PostToolUse` (`Tool("Write|Edit")`); path glob deliberately over-selects on `template`/`bootstrap` (including false positives like a Bootstrap-CSS asset), and the LLM judge is the real filter: it fires only when the edited file plausibly is a canonical/template source distributed to other repos AND the edit itself shows no sign the agent considered propagating the fix. Skips test files. As an LLM primitive, it ships without inline `tests=` per this repo's own convention (`references/capt-hook-api.md`: "LLM hooks ship without tests= — their inline tests would only exercise a stubbed model").

`uv run --project . capt-hook test` was run in the worktree: 309/315 passed. The 6 failures are pre-existing and unrelated to this change — I confirmed they reproduce identically with `bootstrap.py` removed entirely (same 6 failures, same messages), and CI is green on `main` at HEAD, so these are local non-determinism in existing LLM-judged nudge/gate assertions (`nudge_record_evidence`, `nudge_ephemeral_record_reference`, `nudge_plan_tasks`, `general.docs`), not a regression from this PR. This PR's own hook contributes zero new tests and zero new failures.

## Evidence

Correction given in `github.com/yasyf/cc-notes` session `9e5a15d4-86eb-4acb-ba07-154b22d8918d`, 2026-07-08, verbatim (typos included — this is the user's actual answer inside an `AskUserQuestion` response, picking option 1 on a version-skew fix while appending the correction):

- "1, but make the change in the templaet script and across all bootstrapepd repo as well where relevant " — session `9e5a15d4-86eb-4acb-ba07-154b22d8918d`, 2026-07-08

Routed to the general pack rather than a repo-local hook because `capt-hook review show 854` reports `seen_in_repos: 5` — this same rule slug (`centralize-shared-fixes-in-bootstrap`) has independently surfaced as a candidate across 5 different repos, the scanning-sessions skill's documented signal for a generic behavioral rule rather than one specific to cc-notes' own `ensure-cc-notes.sh`.

---
Opened by capt-hook's session reviewer (candidate #854). Merging adopts the rule; closing rejects it and the reviewer will not re-propose this candidate.