### PR TITLE
[capt-hook] Force read-only after re-entering plan mode

### DIFF
--- a/captain_hook/builtin_packs/general/hooks/plans.py
+++ b/captain_hook/builtin_packs/general/hooks/plans.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
-from captain_hook import Allow, Block, Event, Input, RewritingExistingPlan, T, Tool, hook
+from captain_hook import (
+    Allow,
+    Block,
+    Clause,
+    Event,
+    Input,
+    Phrase,
+    RewritingExistingPlan,
+    T,
+    Tool,
+    UsedTool,
+    UserSaid,
+    hook,
+)
 
 hook(
     Event.PreToolUse,
@@ -36,5 +49,57 @@ hook(
         Input(tool="Write", file="/x/plans/p.md", content="# Plan", transcript=[]): Allow(),
         # Not a plan file -> allow.
         Input(tool="Write", file="/x/src/main.py", content="x = 1"): Allow(),
+    },
+)
+
+
+hook(
+    Event.PreToolUse,
+    only_if=[
+        Tool.EditTools,
+        UserSaid(
+            Clause(
+                noun=Phrase("mode", "planning"),
+                verb=Phrase("enter", "re-enter", "reenter", "return", "go", "switch", "get", "come"),
+                subject=("unnamed",),
+            ),
+            Clause(noun=Phrase("work"), verb=Phrase("do"), negated=True),
+            Clause(noun=Phrase("work"), verb=Phrase("stop", "halt", "pause")),
+        ),
+    ],
+    skip_if=[UsedTool("EnterPlanMode")],
+    message=(
+        "The user told you to stop and go back into plan mode. Call EnterPlanMode and "
+        "present a plan for approval before making any more edits."
+    ),
+    block=True,
+    tests={
+        Input(
+            tool="Edit",
+            file="/x/src/main.py",
+            content="x = 1",
+            transcript=[T.user("Re-enter plan mode, don't do any more work.")],
+        ): Block(pattern="plan mode"),
+        Input(
+            tool="Write",
+            file="/x/src/main.py",
+            content="x = 1",
+            transcript=[T.user("Stop all work until we agree on a plan.")],
+        ): Block(),
+        Input(
+            tool="Edit",
+            file="/x/src/main.py",
+            content="x = 1",
+            transcript=[
+                T.user("Re-enter plan mode, don't do any more work."),
+                T.assistant(T.tool("EnterPlanMode")),
+            ],
+        ): Allow(),
+        Input(
+            tool="Edit",
+            file="/x/src/main.py",
+            content="x = 1",
+            transcript=[T.user("please fix the typo in main.py")],
+        ): Allow(),
     },
 )


### PR DESCRIPTION
## Issue

"Re-enter plan mode, don't do any more work" is a hard stop — but nothing enforced it. The agent could acknowledge the directive and keep right on editing, and the only recourse was repeating yourself.

## Fix

A `general`-pack guard that blocks edit tools once the turn's opening prompt carries a stop-and-replan directive, until the agent actually calls `EnterPlanMode` that turn. Matching is grammatical — `Clause`s over the prompt's dependency parse — so "we should return to plan mode" fires while "the app enters sleep mode when idle" stays quiet.

## Example

```text
user  › Re-enter plan mode, don't do any more work.
agent › Edit(src/main.py)
hook  › ⛔ The user told you to stop and go back into plan mode. Call
        EnterPlanMode and present a plan for approval before making any
        more edits.
agent › EnterPlanMode(plan="…")   ← edits stay blocked until this
```
