### PR TITLE
[capt-hook] Fix steering misfiring on bug-mechanism description

### DIFF
--- a/captain_hook/builtin_packs/steering/hooks/steering.py
+++ b/captain_hook/builtin_packs/steering/hooks/steering.py
@@ -77,6 +77,12 @@ nudge(
         threshold=2,
         window=15,
         scope="text",
+        vetoes=[
+            # A relative clause ("which/that leaves ... unset") describes a bug's mechanism in
+            # the third person — not the assistant electing to leave an issue unaddressed — but
+            # still trips the issue/leave clause above (misfire watched live 2026-07-24).
+            Signal(pattern=r"(?i)\b(?:which|that)\s+leaves?\b"),
+        ],
     ),
     tests={
         Input(transcript=[T.assistant("Pre-existing, not caused by my changes.")]): Warn(),
@@ -250,6 +256,19 @@ nudge(
         Input(transcript=[T.assistant("The previous issue is beyond the scope of this change.")]): Warn(),
         # f21 word-boundary: "unknown bugs" must not match the "known bug" arm
         Input(transcript=[T.assistant("There are no unknown bugs left outside scope.")]): Allow(),
+        # m7 mechanism-description: diagnosing a race condition's effect ("which leaves the poison
+        # unset") is describing the bug, not electing to leave it — misfire watched live 2026-07-24
+        Input(
+            transcript=[
+                T.assistant(
+                    "If it happens after the flag is set, the frame fails, triggering a redo-leg "
+                    "failure without an abort, which leaves the poison unset and causes a flake."
+                )
+            ]
+        ): Allow(),
+        # m7 boundary: a genuine first-person decision to leave an issue still warns even though
+        # the mechanism-description veto is now active
+        Input(transcript=[T.assistant("I'll leave that issue alone for now.")]): Warn(),
     },
 )
 


### PR DESCRIPTION
## Issue

The Code Stewardship nudge (`nudge_1ebed8c4`) fired on a genuine, first-person status report about actively hardening a flaky test — Claude's own complaint: "That stewardship hook is a misfire — it pattern-matched on my diagnosis wording, but I'm doing the opposite of dismissing: the flake is being fixed properly..." (session `bab9b475-f6ef-43b7-a44e-cf484dfe4ff4`, 2026-07-24). The actual offending text, traced back through the transcript, was a diagnostic sentence describing the race condition's mechanism: "...triggering a redo-leg failure without an abort, which leaves the poison unset and causes a flake." The hook's `issue_leave_prospective` NlpSignal clause (noun ∈ {issue, bug, failure, ...} + verb "leave", prospective tense) matched "failure" + "leaves" via the relative clause "which leaves", even though the subject is the bug's mechanism, not the assistant electing to leave anything unaddressed.

## Fix

`captain_hook/builtin_packs/steering/hooks/steering.py` — added a veto `Signal` (`(?i)\b(?:which|that)\s+leaves?\b`) to the nudge's `Signals` bundle, suppressing the relative-clause "which/that leaves" construction that describes a bug's own behavior in the third person. Two inline tests added: the reproduced misfire text now `Allow()`s, and a genuine first-person dismissal ("I'll leave that issue alone for now.") still `Warn()`s. All 69 inline tests pass (`uv run --project . capt-hook --hooks captain_hook/builtin_packs/steering/hooks test`).

## Example

```text
agent › (thinking) "...triggering a redo-leg failure without an abort, which leaves the poison unset and causes a flake."
hook  › (before) ⚠️ You appear to be dismissing a pre-existing issue rather than fixing it...
hook  › (after)  (silent — genuine bug-mechanism description, not a dismissal)
agent › "I'll leave that issue alone for now."
hook  › ⚠️ You appear to be dismissing a pre-existing issue rather than fixing it... (still fires — genuine case)
```

---
Opened by capt-hook's session reviewer (candidate #646). Merging adopts the rule; closing rejects it and the reviewer will not re-propose this candidate.