### PR TITLE
fix(packs): stop recompiling the gitignore accumulation at every walked directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Dispatch no longer recompiles a repository's gitignore patterns once per directory
+  it walks. Every event fingerprints the project to decide whether the cached hook
+  registry still holds, and that fingerprint walks the tree for build manifests with
+  real gitignore semantics: patterns accumulate down the tree, and the accumulation
+  was compiled into a fresh `GitIgnoreSpec` at every directory. On a large monorepo
+  that came to 85,000 pattern compilations and ~390 ms of CPU per hook event, paid
+  again by every hook process the event fans out to. A directory carrying no
+  `.gitignore` now inherits its parent's compiled spec, and one carrying its own
+  compiles only its own lines and concatenates the patterns — the same order, the
+  same matches. The walk drops to ~47 ms on the same repository, and a differential
+  run over 216 trees, three real repositories and 200 generated gitignore layouts
+  among them, agrees with the old walk on every one.
+
 ## [12.21.6] - 2026-08-19
 
 ### Fixed

--- a/captain_hook/packs/manager.py
+++ b/captain_hook/packs/manager.py
@@ -243,6 +243,20 @@ def anchor_pattern(line: str, rel_dir: str) -> str:
     return f"{prefix}{rel_dir}/{tail}" if "/" in pat.rstrip("/") else f"{prefix}{rel_dir}/**/{tail}"
 
 
+def descend_spec(parent: GitIgnoreSpec | None, own: list[str], rel_dir: str) -> GitIgnoreSpec | None:
+    """The gitignore spec governing ``rel_dir``: ``parent`` extended by that directory's own patterns.
+
+    Compiling the accumulated pattern set per directory is quadratic in a deep tree, so a directory
+    that carries no ``.gitignore`` reuses its parent's compiled spec and one that does compiles only
+    its own lines and concatenates the compiled patterns — the same last-match-wins order, and the
+    same result as compiling the accumulation from scratch.
+    """
+    if not own:
+        return parent
+    added = GitIgnoreSpec.from_lines(own if not rel_dir else [anchor_pattern(line, rel_dir) for line in own])
+    return added if parent is None else parent + added
+
+
 def detect_languages(root: Path) -> frozenset[str]:
     """The languages in :data:`LANGUAGE_MARKERS` whose recursive, non-``.gitignore``d build manifest is under ``root``.
 
@@ -254,18 +268,15 @@ def detect_languages(root: Path) -> frozenset[str]:
     """
     pending = dict(LANGUAGE_MARKERS)
     found: set[str] = set()
-    lines_by_dir: dict[str, list[str]] = {}
+    specs: dict[str, GitIgnoreSpec | None] = {}
     for dirpath, dirnames, filenames in os.walk(root):
         rel = os.path.relpath(dirpath, root)
         rel_dir = "" if rel == "." else rel
-        own = gitignore_lines(Path(dirpath) / ".gitignore")
-        acc = (
-            own
-            if not rel_dir
-            else lines_by_dir.get(os.path.dirname(dirpath), []) + [anchor_pattern(line, rel_dir) for line in own]
+        spec = specs[dirpath] = descend_spec(
+            specs.get(os.path.dirname(dirpath)),
+            gitignore_lines(Path(dirpath) / ".gitignore"),
+            rel_dir,
         )
-        lines_by_dir[dirpath] = acc
-        spec = GitIgnoreSpec.from_lines(acc) if acc else None
         for lang, markers in list(pending.items()):
             if any(
                 m in filenames and (spec is None or not spec.match_file(f"{rel_dir}/{m}" if rel_dir else m))

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -275,6 +275,12 @@ def test_detect_languages_finds_both(tmp_path: Path) -> None:
         pytest.param({".gitignore": "**/pyproject.toml\n", "svc/pyproject.toml": "x"}, frozenset(), id="double-star"),
         # A negation re-includes a marker an earlier pattern excluded, so it counts.
         pytest.param({".gitignore": "*.mod\n!go.mod\n", "go.mod": "x"}, frozenset({"go"}), id="negation-reincludes"),
+        # A nested negation re-includes a marker the parent's pattern excluded, across both levels.
+        pytest.param(
+            {".gitignore": "*.mod\n", "sub/.gitignore": "!go.mod\n", "sub/go.mod": "x"},
+            frozenset({"go"}),
+            id="nested-negation-reincludes",
+        ),
     ],
 )
 def test_detect_languages_gitignore_semantics(tmp_path: Path, files: dict[str, str], expected: frozenset[str]) -> None:


### PR DESCRIPTION
## Root cause

Seven `captain_hook.worker` processes on one machine were holding ~1.4 cores steadily,
individuals spiking to 72%, with `lstat` and `read` on top of a `sample` profile.

Every dispatch fingerprints the project root to decide whether the cached hook registry
still holds (`Fingerprint.compute`, `captain_hook/daemon/registry.py`). One of the
fingerprint's inputs is `manager.detect_languages` — a gitignore-aware walk for `go.mod`,
`go.work` and `pyproject.toml`. That walk accumulated pattern lines down the tree and
compiled the whole accumulation into a fresh `GitIgnoreSpec` at *every* directory it
entered. `cProfile` over three walks of the monorepo this daemon serves:

```
   ncalls  tottime  cumtime  filename:lineno(function)
   405912    0.639    1.804  pathspec/patterns/gitignore/base.py:62(_translate_segment_glob)
  3495810    0.582    1.142  re/__init__.py:305(escape)
   256503    0.302    2.830  pathspec/patterns/gitignore/spec.py:152(pattern_to_regex)
     1944    0.055    3.229  pathspec/pathspec.py:286(from_lines)
```

85,501 pattern compilations per walk over 648 directories — roughly 396 patterns
recompiled per directory, and for the ~95% of directories carrying no `.gitignore` of
their own, recompiled from a line list identical to the parent's. Wall cost: 394–409 ms
of CPU per hook event, on the hot path of every event, paid again by every hook process a
single tool call fans out to — 14 concurrent `capt-hookd run --event PostToolUse` were
observed for one session root.

## Fix

`descend_spec(parent, own, rel_dir)` extends a compiled spec instead of recompiling the
accumulation:

- a directory carrying no `.gitignore` reuses its parent's spec object;
- one carrying its own compiles only its own (anchored) lines and concatenates the
  compiled patterns onto the parent's.

`PathSpec.__add__` returns `self.__class__([*self.patterns, *other.patterns])`, so the
composed spec is the same `GitIgnoreSpec` over the same pattern sequence that
`from_lines(parent_lines + own_lines)` would build. Last-match-wins is unchanged, so a
nested negation still re-includes a marker its parent's pattern excluded — a case this
change adds to the existing `test_detect_languages_gitignore_semantics` table.

## Measurements

Same machine, same monorepo root, same 27 MB transcript; median of a warm run, minimum
across three interleaved rounds so machine load cannot flatter either side.

| | before | after |
| --- | --- | --- |
| `detect_languages` on the monorepo | 402.4 ms | 50.6 ms |
| one `PostToolUse` dispatch through `ProductRuntime` | 1678.1 ms | 1310.1 ms |

The walk drops 7.9x. The rest of that dispatch is sidechain transcript re-parsing, fixed
separately in cc-transcript (`Session.walk` reparsed every reachable transcript per
predicate); with both landed the same dispatch measures 214.8 ms.

## Verification

- `uv run pytest` — green, including the new `nested-negation-reincludes` case.
- A differential run of the old walk against the new one over 216 trees — 200 generated
  gitignore layouts (anchored patterns, path patterns, `**`, negations, nested overrides)
  plus this repo, cc-transcript and the monorepo — agrees on every tree.
