### PR TITLE
fix(update): converge the self-updater on the host, not on brew's exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The self-updater reported success on every window while never converging. `run_update` read
+  `brew upgrade`'s exit status as proof of an upgrade, but `brew upgrade` exits 0 against a Cellar
+  that already carries the release, and only `reinstall`/`install` re-run the formula's
+  `post_install` — the step that supersedes the deployed app under `~/Applications`. A machine
+  whose Cellar upgraded without landing the app therefore logged `update ok: 12.21.4 -> v12.21.6`
+  every window while the host it actually ran stayed 12.21.4; one went six days and two releases
+  that way, and would have swallowed every release after them. Each brew lane's outcome is now read
+  back from the host's own ping, `update ok` is written only once the host has reached the release,
+  and the reinstall escalation is bounded to three attempts per release tag so a deployment that
+  cannot converge stops reinstalling forever.
 - Dispatch no longer recompiles a repository's gitignore patterns once per directory
   it walks. Every event fingerprints the project to decide whether the cached hook
   registry still holds, and that fingerprint walks the tree for build manifests with

--- a/captain_hook/update/updater.py
+++ b/captain_hook/update/updater.py
@@ -5,9 +5,18 @@ Wired as a sibling of the review dispatcher on the async SessionStart path
 the dispatch only guards, throttles via the shared :func:`_claim_stamp`, and detaches
 ``capt-hook update run``. The detached child (:func:`run_update`) compares the latest
 ``yasyf/captain-hook`` release against the installed signed host and, when the host is older,
-runs ``brew upgrade --formula`` — retrying with an exact formula reinstall/install to repair a
+runs ``brew upgrade --formula`` — escalating to an exact formula reinstall/install to repair a
 broken deployment — then posts a success or failure banner. Every failure is a notification
 or a breadcrumb; nothing here raises into the dispatch or sets an exit code.
+
+Every outcome is read back from the host, never from brew's exit status. ``brew upgrade``
+exits 0 against a Cellar that is already current, so exit 0 covers both a real upgrade and a
+no-op that left the deployment untouched — the state this converges, where one machine carried
+Cellar 12.21.6 for six days while its host stayed 12.21.4 and every check logged success. Only
+``reinstall``/``install`` re-run the formula's ``post_install``, which supersedes the deployed
+app, so the escalation is what actually repairs that split. It is bounded per release tag by
+:data:`MAX_ESCALATIONS`: a reinstall is heavy, and one that cannot converge must not run on
+every window forever.
 """
 
 from __future__ import annotations
@@ -29,6 +38,8 @@ from captain_hook.util.http import GitHubFetchError, github_get_json
 
 RELEASES_URL = "https://api.github.com/repos/yasyf/captain-hook/releases/latest"
 UPDATE_STAMP = "check.stamp"
+ESCALATION_RECORD = "escalation"
+MAX_ESCALATIONS = 3
 BREW_TIMEOUT = 1800.0
 
 
@@ -76,13 +87,41 @@ def brew(args: list[str]) -> bool:
     return completed.returncode == 0
 
 
-def brew_upgrade() -> bool:
-    """Upgrade or repair the exact formula-owned signed deployment."""
-    return (
-        brew(["upgrade", "--formula", FORMULA])
-        or brew(["reinstall", "--formula", FORMULA])
-        or brew(["install", "--formula", FORMULA])
-    )
+def host_at_least(target: str) -> str | None:
+    """The running host's version once it has reached ``target``; ``None`` while it has not.
+
+    ``package-install`` — the formula's ``post_install`` step — supersedes the deployed app and
+    returns only once the new host answers a ping, so the host's own reply is the proof that a
+    brew lane landed rather than no-opped.
+    """
+    if (installed := installed_version()) is None:
+        return None
+    try:
+        return installed if version_tuple(installed) >= version_tuple(target) else None
+    except ValueError:
+        return None
+
+
+def escalations(target: str) -> int:
+    """Reinstall escalations already spent on ``target``; a newer tag starts a fresh budget."""
+    try:
+        tag, spent = (update_dir() / ESCALATION_RECORD).read_text().split()
+        return int(spent) if tag == target else 0
+    except (OSError, ValueError):
+        return 0
+
+
+def record_escalation(target: str, spent: int) -> None:
+    try:
+        (record := update_dir() / ESCALATION_RECORD).parent.mkdir(parents=True, exist_ok=True)
+        record.write_text(f"{target} {spent}")
+    except OSError:
+        breadcrumb(f"escalation record unwritable for {target}")
+
+
+def settled(previous: str, host: str) -> None:
+    breadcrumb(f"update ok: {previous} -> {host}")
+    notify(kind="update_installed", title="Captain Hook updated", body=f"Upgraded the signed host to {host}.")
 
 
 def notify(*, kind: str, title: str, body: str) -> None:
@@ -94,7 +133,7 @@ def notify(*, kind: str, title: str, body: str) -> None:
 
 
 def run_update() -> None:
-    """The detached child: check the latest release and brew-upgrade an older host.
+    """The detached child: check the latest release and converge an older host onto it.
 
     Never raises — a network, version, or brew failure becomes a breadcrumb or an
     ``update_failed`` banner, so the async dispatch can never be affected.
@@ -115,14 +154,21 @@ def run_update() -> None:
     if current:
         breadcrumb(f"update skip: host {installed} current (latest {latest})")
         return
-    if brew_upgrade():
-        breadcrumb(f"update ok: {installed} -> {latest}")
-        notify(kind="update_installed", title="Captain Hook updated", body=f"Upgraded the signed host to {latest}.")
-    else:
-        breadcrumb(f"update failed: could not upgrade to {latest}")
-        notify(
-            kind="update_failed", title="Captain Hook update failed", body=f"Could not upgrade the host to {latest}."
-        )
+    brew(["upgrade", "--formula", FORMULA])
+    if (host := host_at_least(latest)) is not None:
+        settled(installed, host)
+        return
+    if (spent := escalations(latest)) >= MAX_ESCALATIONS:
+        breadcrumb(f"update stalled: host {installed} short of {latest} after {spent} escalations")
+        return
+    record_escalation(latest, spent + 1)
+    for lane in ("reinstall", "install"):
+        brew([lane, "--formula", FORMULA])
+        if (host := host_at_least(latest)) is not None:
+            settled(installed, host)
+            return
+    breadcrumb(f"update failed: host {installed} did not reach {latest}")
+    notify(kind="update_failed", title="Captain Hook update failed", body=f"Could not upgrade the host to {latest}.")
 
 
 def update_argv() -> list[str]:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -38,6 +38,22 @@ def stub_installed(monkeypatch: pytest.MonkeyPatch, version: str) -> None:
     monkeypatch.setattr(client, "send", lambda *a, **k: {"ok": True, "version": version})
 
 
+def stub_converging(monkeypatch: pytest.MonkeyPatch, before: str, after: str, *, on: str) -> dict[str, str]:
+    """Report ``before`` until the ``on`` brew lane runs, then ``after`` — a landed supersede."""
+    host = {"version": before}
+    monkeypatch.setattr(client, "send", lambda *a, **k: {"ok": True, "version": host["version"]})
+    original = updater.brew
+
+    def converging(args: list[str]) -> bool:
+        outcome = original(args)
+        if args[0] == on:
+            host["version"] = after
+        return outcome
+
+    monkeypatch.setattr(updater, "brew", converging)
+    return host
+
+
 def record_brew(monkeypatch: pytest.MonkeyPatch, returncode: Any) -> list[list[str]]:
     calls: list[list[str]] = []
 
@@ -72,15 +88,79 @@ def test_run_update_upgrades_when_host_is_older(
     monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
 ) -> None:
     stub_release(monkeypatch, "v2.0.0")
-    stub_installed(monkeypatch, "1.0.0")
     brew = record_brew(monkeypatch, 0)
+    stub_converging(monkeypatch, "1.0.0", "2.0.0", on="upgrade")
 
     updater.run_update()
 
     assert brew == [UPGRADE]
     assert notes == [
-        {"kind": "update_installed", "title": "Captain Hook updated", "body": "Upgraded the signed host to v2.0.0."}
+        {"kind": "update_installed", "title": "Captain Hook updated", "body": "Upgraded the signed host to 2.0.0."}
     ]
+
+
+def test_run_update_escalates_when_upgrade_exits_clean_without_converging(
+    monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
+) -> None:
+    """PIN: a Cellar already carrying the release makes ``brew upgrade`` a successful no-op.
+
+    The deployed app stays behind, so exit 0 must not be read as an upgrade — the escalation
+    that re-runs ``post_install`` is what supersedes it.
+    """
+    stub_release(monkeypatch, "v2.0.0")
+    brew = record_brew(monkeypatch, 0)
+    stub_converging(monkeypatch, "1.0.0", "2.0.0", on="reinstall")
+
+    updater.run_update()
+
+    assert brew == [UPGRADE, REINSTALL]
+    assert [n["kind"] for n in notes] == ["update_installed"]
+
+
+def test_run_update_reports_a_failure_when_nothing_converges(
+    monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
+) -> None:
+    stub_release(monkeypatch, "v2.0.0")
+    stub_installed(monkeypatch, "1.0.0")
+    brew = record_brew(monkeypatch, 0)
+
+    updater.run_update()
+
+    assert brew == [UPGRADE, REINSTALL, INSTALL]
+    assert [n["kind"] for n in notes] == ["update_failed"]
+
+
+def test_run_update_stops_escalating_after_the_budget(
+    monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
+) -> None:
+    stub_release(monkeypatch, "v2.0.0")
+    stub_installed(monkeypatch, "1.0.0")
+    brew = record_brew(monkeypatch, 0)
+
+    for _ in range(updater.MAX_ESCALATIONS + 2):
+        updater.run_update()
+
+    assert brew.count(REINSTALL) == updater.MAX_ESCALATIONS
+    assert brew.count(UPGRADE) == updater.MAX_ESCALATIONS + 2
+    assert [n["kind"] for n in notes] == ["update_failed"] * updater.MAX_ESCALATIONS
+
+
+def test_run_update_gives_a_newer_release_a_fresh_budget(
+    monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
+) -> None:
+    stub_release(monkeypatch, "v2.0.0")
+    stub_installed(monkeypatch, "1.0.0")
+    record_brew(monkeypatch, 0)
+    for _ in range(updater.MAX_ESCALATIONS):
+        updater.run_update()
+
+    stub_release(monkeypatch, "v3.0.0")
+    brew = record_brew(monkeypatch, 0)
+    stub_converging(monkeypatch, "1.0.0", "3.0.0", on="reinstall")
+    updater.run_update()
+
+    assert brew == [UPGRADE, REINSTALL]
+    assert notes[-1]["kind"] == "update_installed"
 
 
 def test_run_update_skips_when_host_is_current(monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]) -> None:
@@ -98,8 +178,8 @@ def test_run_update_reinstalls_and_recovers_husk(
     monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
 ) -> None:
     stub_release(monkeypatch, "v2.0.0")
-    stub_installed(monkeypatch, "1.0.0")
     brew = record_brew(monkeypatch, lambda argv: 1 if argv[1] == "upgrade" else 0)
+    stub_converging(monkeypatch, "1.0.0", "2.0.0", on="reinstall")
 
     updater.run_update()
 


### PR DESCRIPTION
Stacked on #14 (base `fix/gitignore-spec-per-directory`) — both touch `## [Unreleased]`, so a shared base keeps the changelog from conflicting on the second merge.

## Root cause

This machine's daemon had been two releases behind for six days while the updater logged success
every window:

- brew Cellar: `captain-hook 12.21.6`, installed Aug 20 18:18, not outdated.
- `~/Applications/Captain Hook.app`, the deployment the daemon actually runs:
  `CFBundleShortVersionString` **12.21.4**.
- Live daemon (started Aug 20 17:56) still spawning `~/.daemonkit/tools/capt-hook/12.21.4/` workers;
  build fencing keeps host and workers together, so the running host was 12.21.4.
- `~/.claude/state/update/update.log`: `update ok: 12.21.4 -> v12.21.6`, **six times**.

`run_update` treated brew's exit status as proof of an upgrade:

```python
if brew_upgrade():                                   # upgrade || reinstall || install
    breadcrumb(f"update ok: {installed} -> {latest}")
```

`brew upgrade --formula` exits **0** against a Cellar that already carries the release, so the
`or` chain short-circuits and `reinstall` never runs. But the Cellar is not the deployment: the
formula installs the app into `libexec` and lands it via

```ruby
def post_install
  system libexec/"Captain Hook.app/Contents/Helpers/capt-hookd", "package-install"
end
```

and Homebrew runs `post_install` on install/reinstall, not on an upgrade that had nothing to do.
So a Cellar that upgraded without landing the app is a stable fixed point: every window re-runs a
successful no-op, reports `update ok`, and converges on nothing. It would have swallowed every
future release, not just this one.

## Fix

Read the outcome back from the host, never from brew's exit code. `host_at_least(target)` pings
the running host and returns its version only once it has reached the release — sound because
`package-install` → `applyPackagedApplication` quiesces the incumbent, supersedes the bundle,
activates, validates, and ends on `pingBridge`, so it returns only when the new host is answering.

- `brew upgrade` runs first and, when the host moves, we are done — unchanged for the normal case.
- Exit 0 without movement now falls through to `reinstall`, then `install`, each re-checked against
  the host. That is the lane that re-runs `post_install`, so it repairs precisely the split above.
- `update ok: X -> Y` is written only when the host actually became Y, and Y is the host's own
  reported version rather than the release tag. A run that escalates and still does not converge
  logs `update failed` and notifies.

## The bound

A reinstall is heavy, so it is budgeted at **`MAX_ESCALATIONS = 3` attempts per release tag**,
recorded in `~/.claude/state/update/escalation`. With the 720-minute check interval that is about
36 hours of trying before the updater stops escalating for that tag; past the budget it still runs
the cheap `brew upgrade` and logs `update stalled: host X short of Y after N escalations` without
re-notifying — the failure banner already fired on each of the three spending runs. A newer tag
starts a fresh budget, so a genuinely new release is never blocked by an older one that gave up.

## What I verified, and what I did not

Verified: the full suite is green, including a test that reproduces the exact misfire (`brew
upgrade` exits 0, the host does not move, the escalation runs) and one that pins the budget and its
per-tag reset. The `post_install` → `package-install` → supersede chain is read from the formula in
`yasyf/homebrew-tap` and from `internal/hookd/{command,deployment}.go`.

Not verified: no real `brew reinstall`, and nothing was run against the live host. That escalation
supersedes the running daemon, and 22+ sessions depend on this one — the end-to-end exercise
belongs on a scratch install, not here.

## Flagged, deliberately not in this PR

`dispatch_update` skips headless sessions (`update skip: sdk entrypoint` — 1,403 of the 1,516 lines
in that log). Including them looks like a one-line change but is a design decision, not an
oversight: the escalation supersedes the running daemon, and firing that from an agent-launched
session would drain hook dispatch under whatever else is running. Interactive sessions do reach the
check (7 spawned runs, 81 throttled in the same log), so the throttle is working as designed. Worth
a separate decision, not a rider here.
