### PR TITLE
feat(update): let agent sessions check for a release without superseding the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Agent-launched sessions now take part in the update check. `dispatch_update` skipped every
+  headless session outright, so on a machine where most sessions are agent-launched the check fell
+  to whichever interactive session happened along — 1,403 of 1,516 lines in one update log were
+  `update skip: sdk entrypoint`. A headless session now runs the same release check and records
+  what it finds, but never runs a brew lane: converging supersedes the running daemon, and an agent
+  session acting on that would drain hook dispatch under every other session the daemon serves. The
+  next interactive session applies the deferral immediately, claiming an apply stamp of its own
+  rather than waiting out a check window its headless peer already claimed, and only one such apply
+  runs per window.
+
 ### Fixed
 
 - The self-updater reported success on every window while never converging. `run_update` read

--- a/captain_hook/update/cli.py
+++ b/captain_hook/update/cli.py
@@ -11,8 +11,9 @@ def update() -> None:
 
 
 @update.command(name="run")
-def run_hook() -> None:
+@click.option("--check-only", is_flag=True, help="Record a newer release for the next session to act on.")
+def run_hook(check_only: bool) -> None:
     """Check the latest release and brew-upgrade an older host (spawned by the SessionStart dispatch)."""
     from captain_hook.update.updater import run_update
 
-    run_update()
+    run_update(apply=not check_only)

--- a/captain_hook/update/updater.py
+++ b/captain_hook/update/updater.py
@@ -17,6 +17,11 @@ Cellar 12.21.6 for six days while its host stayed 12.21.4 and every check logged
 app, so the escalation is what actually repairs that split. It is bounded per release tag by
 :data:`MAX_ESCALATIONS`: a reinstall is heavy, and one that cannot converge must not run on
 every window forever.
+
+Checking and acting are separate lanes because superseding the daemon interrupts every session it
+serves. Every session checks; only one that may take hook dispatch down acts. A headless session
+runs :func:`run_update` with ``apply=False``, which records the divergence and stops; the next
+interactive session picks that deferral up and converges.
 """
 
 from __future__ import annotations
@@ -38,7 +43,9 @@ from captain_hook.util.http import GitHubFetchError, github_get_json
 
 RELEASES_URL = "https://api.github.com/repos/yasyf/captain-hook/releases/latest"
 UPDATE_STAMP = "check.stamp"
+APPLY_STAMP = "apply.stamp"
 ESCALATION_RECORD = "escalation"
+PENDING_RECORD = "pending"
 MAX_ESCALATIONS = 3
 BREW_TIMEOUT = 1800.0
 
@@ -102,6 +109,29 @@ def host_at_least(target: str) -> str | None:
         return None
 
 
+def pending() -> str | None:
+    """The release a check-only run deferred to the next session allowed to act on it."""
+    try:
+        return (update_dir() / PENDING_RECORD).read_text().strip() or None
+    except OSError:
+        return None
+
+
+def record_pending(target: str) -> None:
+    try:
+        (record := update_dir() / PENDING_RECORD).parent.mkdir(parents=True, exist_ok=True)
+        record.write_text(target)
+    except OSError:
+        breadcrumb(f"pending record unwritable for {target}")
+
+
+def clear_pending() -> None:
+    try:
+        (update_dir() / PENDING_RECORD).unlink(missing_ok=True)
+    except OSError:
+        breadcrumb("pending record unclearable")
+
+
 def escalations(target: str) -> int:
     """Reinstall escalations already spent on ``target``; a newer tag starts a fresh budget."""
     try:
@@ -132,8 +162,13 @@ def notify(*, kind: str, title: str, body: str) -> None:
         )
 
 
-def run_update() -> None:
-    """The detached child: check the latest release and converge an older host onto it.
+def run_update(*, apply: bool = True) -> None:
+    """The detached child: check the latest release and, when allowed to act, converge onto it.
+
+    ``apply=False`` is the agent-session lane. It runs the same release check and records the
+    divergence it finds, but never runs a brew lane: converging supersedes the running daemon, and
+    an agent-launched session is precisely where that would drain hook dispatch under work already
+    in flight. The next session that may act picks the deferral up from :func:`pending`.
 
     Never raises — a network, version, or brew failure becomes a breadcrumb or an
     ``update_failed`` banner, so the async dispatch can never be affected.
@@ -152,8 +187,14 @@ def run_update() -> None:
         breadcrumb(f"update skip: unparseable version (installed {installed}, latest {latest})")
         return
     if current:
+        clear_pending()
         breadcrumb(f"update skip: host {installed} current (latest {latest})")
         return
+    if not apply:
+        record_pending(latest)
+        breadcrumb(f"update deferred: host {installed} short of {latest}; an agent session may not supersede")
+        return
+    clear_pending()
     brew(["upgrade", "--formula", FORMULA])
     if (host := host_at_least(latest)) is not None:
         settled(installed, host)
@@ -171,18 +212,18 @@ def run_update() -> None:
     notify(kind="update_failed", title="Captain Hook update failed", body=f"Could not upgrade the host to {latest}.")
 
 
-def update_argv() -> list[str]:
+def update_argv(*, apply: bool) -> list[str]:
     # -P: detach() runs this from the session's repo, and `-m` would otherwise put that repo at the
     # head of sys.path, where a directory sharing a dependency's name shadows the installed one.
-    return [sys.executable, "-P", "-m", "captain_hook", "update", "run"]
+    return [sys.executable, "-P", "-m", "captain_hook", "update", "run", *([] if apply else ["--check-only"])]
 
 
-def detach() -> None:
+def detach(*, apply: bool) -> None:
     try:
         (log_path := update_log_path()).parent.mkdir(parents=True, exist_ok=True)
         with log_path.open("ab") as log:
             subprocess.Popen(
-                update_argv(),
+                update_argv(apply=apply),
                 stdin=subprocess.DEVNULL,
                 stdout=log,
                 stderr=log,
@@ -193,13 +234,13 @@ def detach() -> None:
     except OSError:
         breadcrumb("detach failed: update run")
         return
-    breadcrumb("spawned update run")
+    breadcrumb(f"spawned update run{'' if apply else ' (check only)'}")
 
 
-def claim_update(settings: UpdateSettings) -> bool:
+def claim(stamp: str, settings: UpdateSettings) -> bool:
     try:
         (stamps := update_dir()).mkdir(parents=True, exist_ok=True)
-        return _claim_stamp(stamps / UPDATE_STAMP, timedelta(minutes=settings.interval_minutes))
+        return _claim_stamp(stamps / stamp, timedelta(minutes=settings.interval_minutes))
     except OSError:
         return False
 
@@ -207,19 +248,27 @@ def claim_update(settings: UpdateSettings) -> bool:
 def dispatch_update() -> None:
     """Async SessionStart entry (sibling of the review dispatcher): throttle and detach the updater.
 
-    Never raises and never blocks: skips a disabled config, a spawned or headless session, claims the
-    shared interval stamp so a burst of sessions triggers at most one check per window, then detaches
+    Never raises and never blocks: skips a disabled config and a spawned session, claims an interval
+    stamp so a burst of sessions triggers at most one run per window, then detaches
     ``capt-hook update run`` so a multi-minute ``brew upgrade`` runs off the hook's thread.
+
+    Every session checks; only a session that may supersede the daemon acts. A headless one detaches
+    the check-only lane, which records what it finds without running a brew lane, so an
+    agent-launched session can never interrupt hook dispatch in flight. An interactive session
+    carrying a deferral acts on it immediately, claiming :data:`APPLY_STAMP` instead of waiting out a
+    check window a headless peer already claimed — one apply per window, whichever session brings it.
     """
     if not (settings := UpdateSettings()).enabled:
         return
     if reqenv.getenv(SPAWNED_ENV):
         breadcrumb("update skip: CAPT_HOOK_SPAWNED set")
         return
-    if reqenv.is_headless():
-        breadcrumb("update skip: sdk entrypoint")
-        return
-    if not claim_update(settings):
+    apply = not reqenv.is_headless()
+    if apply and pending() is not None:
+        if not claim(APPLY_STAMP, settings):
+            breadcrumb("update skip: a deferred update is already claimed")
+            return
+    elif not claim(UPDATE_STAMP, settings):
         breadcrumb("update skip: throttled")
         return
-    detach()
+    detach(apply=apply)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -223,22 +223,26 @@ def test_run_update_skips_when_installed_version_unavailable(
     assert notes == []
 
 
+def record_detach(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+    detaches: list[bool] = []
+    monkeypatch.setattr(updater, "detach", lambda *, apply: detaches.append(apply))
+    return detaches
+
+
 def test_dispatch_detaches_once_per_throttle_window(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CAPT_HOOK_SPAWNED", raising=False)
-    detaches: list[int] = []
-    monkeypatch.setattr(updater, "detach", lambda: detaches.append(1))
+    detaches = record_detach(monkeypatch)
 
     updater.dispatch_update()
     updater.dispatch_update()
 
-    assert detaches == [1]
+    assert detaches == [True]
 
 
 def test_dispatch_skips_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CAPT_HOOK_SPAWNED", raising=False)
     monkeypatch.setenv("HOOKS_UPDATE_ENABLED", "false")
-    detaches: list[int] = []
-    monkeypatch.setattr(updater, "detach", lambda: detaches.append(1))
+    detaches = record_detach(monkeypatch)
 
     updater.dispatch_update()
 
@@ -247,9 +251,83 @@ def test_dispatch_skips_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_dispatch_skips_a_spawned_session(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CAPT_HOOK_SPAWNED", "1")
-    detaches: list[int] = []
-    monkeypatch.setattr(updater, "detach", lambda: detaches.append(1))
+    detaches = record_detach(monkeypatch)
 
     updater.dispatch_update()
 
     assert detaches == []
+
+
+def test_dispatch_checks_an_agent_session_without_letting_it_apply(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PIN: a headless session participates in the check and can never supersede the daemon.
+
+    Converging quiesces and replaces the running host, so an agent-launched session acting on it
+    would drain hook dispatch under every other session the daemon serves.
+    """
+    monkeypatch.delenv("CAPT_HOOK_SPAWNED", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-py")
+    detaches = record_detach(monkeypatch)
+
+    updater.dispatch_update()
+
+    assert detaches == [False]
+    assert updater.update_argv(apply=False)[-1] == "--check-only"
+
+
+def test_the_check_only_flag_reaches_run_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    from click.testing import CliRunner
+
+    from captain_hook.update.cli import update
+
+    applied: list[bool] = []
+    monkeypatch.setattr(updater, "run_update", lambda *, apply: applied.append(apply))
+
+    assert CliRunner().invoke(update, ["run", "--check-only"]).exit_code == 0
+    assert CliRunner().invoke(update, ["run"]).exit_code == 0
+    assert applied == [False, True]
+
+
+def test_check_only_records_the_divergence_and_runs_no_brew_lane(
+    monkeypatch: pytest.MonkeyPatch, notes: list[dict[str, object]]
+) -> None:
+    stub_release(monkeypatch, "v2.0.0")
+    stub_installed(monkeypatch, "1.0.0")
+    brew = record_brew(monkeypatch, 0)
+
+    updater.run_update(apply=False)
+
+    assert brew == []
+    assert notes == []
+    assert updater.pending() == "v2.0.0"
+
+
+def test_a_deferred_update_is_applied_by_the_next_interactive_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CAPT_HOOK_SPAWNED", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-py")
+    stub_release(monkeypatch, "v2.0.0")
+    stub_installed(monkeypatch, "1.0.0")
+    record_brew(monkeypatch, 0)
+    detaches = record_detach(monkeypatch)
+
+    updater.dispatch_update()
+    updater.run_update(apply=False)
+    assert updater.pending() == "v2.0.0"
+
+    monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
+    updater.dispatch_update()
+    updater.dispatch_update()
+
+    assert detaches == [False, True]
+
+
+def test_a_converged_host_drops_the_deferral(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_release(monkeypatch, "v2.0.0")
+    stub_installed(monkeypatch, "1.0.0")
+    record_brew(monkeypatch, 0)
+    updater.run_update(apply=False)
+    assert updater.pending() == "v2.0.0"
+
+    stub_installed(monkeypatch, "2.0.0")
+    updater.run_update(apply=False)
+
+    assert updater.pending() is None

--- a/tests/test_userpath.py
+++ b/tests/test_userpath.py
@@ -183,4 +183,4 @@ def test_update_spawn_is_import_isolated() -> None:
     # updater.detach() spawns from the session's repo too, so it needs the same isolation.
     from captain_hook.update.updater import update_argv
 
-    assert update_argv()[:4] == [sys.executable, "-P", "-m", "captain_hook"]
+    assert update_argv(apply=True)[:4] == [sys.executable, "-P", "-m", "captain_hook"]


### PR DESCRIPTION
Stacked on #15 (base `fix/updater-converges-on-the-host`), which is itself stacked on #14.

## The gap

`dispatch_update` skipped every headless session outright:

```python
if reqenv.is_headless():
    breadcrumb("update skip: sdk entrypoint")
    return
```

On a machine where most sessions are agent-launched that is nearly the whole population — 1,403 of
the 1,516 lines in one `update.log` are `update skip: sdk entrypoint` — so noticing a release fell
to whichever interactive session happened along.

## Why the skip existed, and what actually had to be separated

Converging is not a background download. `brew reinstall` re-runs the formula's `post_install`,
which runs `capt-hookd package-install` → `applyPackagedApplication`: it quiesces the incumbent
daemon, supersedes the bundle, activates, and pings the new host. That takes hook dispatch down for
**every session the daemon serves**, not just the one that triggered it. Firing that from an
agent-launched session means interrupting work in flight, on a machine currently running 22+ of
them.

But the check was never the dangerous half. `run_update` already had the seam: fetch the release
tag, ping the host for its version, compare — then act. Only the brew lanes supersede anything.

## Approach: detect-and-defer, with a hand-off

I took detect-and-defer rather than a quiescence gate. A gate ("supersede only when no dispatch is
in flight") would need a new daemon query, and the answer is momentary while the supersede is not —
the window closes under you, which is a race rather than a guarantee. Deferral needs no new
protocol and gives a real one: the lane that cannot safely act simply never reaches the code that
acts.

- `run_update(apply=False)` is the agent-session lane. It runs the identical release check and
  writes the divergence to `pending`, then returns — before any `brew` call.
- `dispatch_update` picks the lane from `reqenv.is_headless()` and passes it to the detached child
  as `--check-only`, so the child cannot apply either, whatever it decides.
- An interactive session with a deferral acts on it **immediately**, claiming `apply.stamp` instead
  of the check stamp — otherwise a headless peer's check claim would sit on the fix for up to the
  full 720-minute window. One apply per window still, whichever session brings it: the claim is the
  same atomic `O_CREAT|O_EXCL` stamp the review pipeline uses, so a burst of interactive sessions
  cannot start concurrent reinstalls.
- The deferral is cleared when the host is already current and when an apply run takes it up, so it
  never goes stale. If that apply fails to converge, the next headless check simply re-records it.

## An agent-launched session cannot interrupt in-flight dispatch

Three independent points, each pinned by a test:

1. `dispatch_update` under `CLAUDE_CODE_ENTRYPOINT=sdk-*` detaches with `apply=False`
   (`test_dispatch_checks_an_agent_session_without_letting_it_apply`).
2. `run_update(apply=False)` returns before any brew lane — the test asserts the recorded brew
   calls are exactly `[]` and that no notification fires
   (`test_check_only_records_the_divergence_and_runs_no_brew_lane`).
3. The detached child carries `--check-only`, and the flag reaches `run_update(apply=False)` through
   the Click command (`test_the_check_only_flag_reaches_run_update`).

Supersession happens only inside `brew reinstall`/`brew install`, both of which are downstream of
`apply`. There is no path from a headless session to either.

## Scope

Who checks and when supersession is safe — no redesign. The escalation, its budget, and the
convergence read from #15 are untouched. `CAPT_HOOK_SPAWNED` still skips outright: those are the
updater's own children, not sessions.

Tested against the module's existing mock seams (mocked `brew`, mocked host ping) — nothing was run
against the live host.
