### PR TITLE
chore(deps): daemonkit v0.23.0 on both halves, and HelperPaths stops deriving the socket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/yasyf/captain-hook
 
 go 1.26.3
 
-require github.com/yasyf/daemonkit v0.21.2
+require github.com/yasyf/daemonkit v0.23.0
 
 require (
 	github.com/ebitengine/purego v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/yasyf/daemonkit v0.21.2 h1:cutqqhIatqIq41219CwAiRvnQDrsZtNFOteETTwqNtU=
-github.com/yasyf/daemonkit v0.21.2/go.mod h1:wn6ImONXaBW3uf7GJO68nGd/KR2PjxXy4r/m9W3gDOM=
+github.com/yasyf/daemonkit v0.23.0 h1:3ov00O4cEIbXAfj9h6uBpf8PMluGJcGGRvB5IVZhHXY=
+github.com/yasyf/daemonkit v0.23.0/go.mod h1:mnfLEwDeeyEmq7Dj+4/lJZ60sBcdI7GlWXLLuBSapyw=
 go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
 go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/helper/Sources/App/CaptainHookApp.swift
+++ b/helper/Sources/App/CaptainHookApp.swift
@@ -52,7 +52,7 @@ struct CaptainHookApp: App {
             var client: ServiceSocketClient?
             do {
                 let connected = try ServiceSocketClient(
-                    path: HelperPaths.hostSocket.path,
+                    path: HelperPaths.hostSocket().path,
                     schema: helperSchema
                 )
                 client = connected

--- a/helper/Sources/Bridge/CaptainHookBridge.swift
+++ b/helper/Sources/Bridge/CaptainHookBridge.swift
@@ -45,7 +45,7 @@ private enum CaptainHookBridge {
             let input = try payload(for: arguments.operation)
             let deadline = Date().addingTimeInterval(5)
             let client = try await SocketClient(
-                path: HelperPaths.hostSocket.path,
+                path: HelperPaths.hostSocket().path,
                 schema: helperSchema,
                 lane: .business
             )

--- a/helper/Sources/Shared/HelperPaths.swift
+++ b/helper/Sources/Shared/HelperPaths.swift
@@ -13,10 +13,7 @@ enum HelperPaths {
 
     static var status: URL { directory.appendingPathComponent("status.json") }
 
-    // daemonkit derives the serving socket from the label alone: ~/<label>/daemon.sock.
-    static var hostSocket: URL {
-        RealHome.directory()
-            .appendingPathComponent(hostServiceLabel, isDirectory: true)
-            .appendingPathComponent("daemon.sock")
+    static func hostSocket() throws -> URL {
+        try AgentPaths(label: hostServiceLabel).socket()
     }
 }

--- a/helper/project.yml
+++ b/helper/project.yml
@@ -21,7 +21,7 @@ settings:
 packages:
   DaemonKit:
     url: https://github.com/yasyf/daemonkit
-    exactVersion: 0.21.0
+    exactVersion: 0.23.0
 
 targetTemplates:
   HostApp:


### PR DESCRIPTION
captain-hook was split across two daemonkit version axes: Go on v0.21.2, SPM `DaemonKit` on `0.21.0`, and `HelperPaths.hostSocket` hand-reimplementing daemonkit's label-to-socket formula in Swift because the Swift package had no such helper. The comment above it said as much:

> `// daemonkit derives the serving socket from the label alone: ~/<label>/daemon.sock.`

That arrangement only held while the formula never moved. daemonkit v0.22.0 moved it to `~/.daemonkit/agents/<Label>` and v0.23.0 to `~/.daemonkit/a/<Label>`, and a Go-only bump would have left the host serving one path while the helper and the bridge dialed another — no compile error anywhere between them, just a connect that never finds anything.

## What changed

- **Go `go.mod`: v0.21.2 → v0.23.0.**
- **SPM `helper/project.yml`: `exactVersion: 0.21.0` → `0.23.0`.** Both halves now agree, which is the point.
- **`HelperPaths.hostSocket` is `AgentPaths`.** daemonkit v0.23.0 added `AgentPaths` to its Swift package — the derivation that was missing, pinned to Go's `paths.Agent` by a golden both languages assert against. `hostSocket` becomes a throwing accessor over it, so the hand-written copy and its confessional comment are gone and there is nothing left to drift.

Both call sites — `CaptainHookApp.runNotificationConsumer` and `CaptainHookBridge.main` — were already inside `try` contexts, so each is a one-token change.

`AgentPaths.socket()` throws rather than returning a path past darwin's `sun_path`, matching what `paths.Socket` does on the Go side. `com.yasyf.captain-hook.host.v1` under this home resolves to 72 bytes, comfortably clear.

## State moves, and is not migrated

The host comes up fresh under `~/.daemonkit/a/com.yasyf.captain-hook.host.v1`. There is no migration and no fallback read, so the old directory is left where it lies. It should be deleted by hand only after the host is confirmed serving under the new root — and note the gate is the plist being re-materialized, not the binary being upgraded: an unset `Daemon.Log` bakes the old state dir into launchd's `StandardOutPath`, so a directory deleted under a stale plist comes straight back on the next respawn. captain-hook sets an explicit log path, so it is not exposed to that, but the ordering still holds.

## What I could not run

**Nothing Swift was compiled or executed for this change.** This machine has Command Line Tools only, no Xcode, so neither `swift build` nor `xcodebuild` can touch the helper — CI's Swift job is the only grader, and the SPM pin change plus the three edited files are exactly what it grades.

Verified locally: `go build ./...` and `go vet ./...` clean on the Go half, and the daemonkit Swift API this depends on (`AgentPaths(label:).socket()`) was compiled and run against its golden in daemonkit's own release before v0.23.0 was tagged.
