### PR TITLE
feat(packs): guard unbounded find, on the parsed-command primitives

### DIFF
--- a/captain_hook/builtin_packs/general/hooks/commands.py
+++ b/captain_hook/builtin_packs/general/hooks/commands.py
@@ -1,21 +1,30 @@
 from __future__ import annotations
 
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
 from captain_hook import (
     Allow,
     Block,
     CwdHasFiles,
     Event,
     Input,
+    LambdaCondition,
     Or,
     RanCommand,
+    Rewrite,
+    Rewritten,
     Runs,
     Tool,
     UsedSkill,
     Warn,
     hook,
     nudge,
+    rewrite_command_occurrences,
 )
-from captain_hook.types import Command
+
+if TYPE_CHECKING:
+    from captain_hook import BaseHookEvent, Call, Command, HookResult, Occurrence, PreToolUseEvent, WalkContext
 
 hook(
     Event.PreToolUse,
@@ -75,13 +84,36 @@ nudge(
 )
 
 
+VALUE_FLAGS = ("--scope", "--marketplace")
+
+
+def operands(call: Call, *, after: int = 0) -> list[str]:
+    """The call's positional words past ``after``, with flags and their values dropped."""
+    rest: list[str] = []
+    skip = False
+    for arg in call.args[after:]:
+        if skip:
+            skip = False
+        elif arg in VALUE_FLAGS:
+            skip = True
+        elif not arg.startswith("-"):
+            rest.append(arg)
+    return rest
+
+
+def updates_a_bare_plugin(evt: BaseHookEvent) -> bool:
+    return any(
+        call.args[:2] == ("plugin", "update") and any("@" not in name for name in operands(call, after=2))
+        for call in evt.command.calls("claude")
+    )
+
+
 nudge(
     "`claude plugin update <name>` with a bare name fails 'not found', and the scope silently "
     "defaults to user regardless of cwd. Take the qualifier and scope from the plugin's "
     "~/.claude/plugins/installed_plugins.json record and pass them: "
     "`claude plugin update <plugin>@<marketplace> --scope <scope>`.",
-    only_if=[Tool("Bash"), Command(r"\bclaude\s+plugin\s+update\s+\S")],
-    skip_if=[Command(r"plugin\s+update\b[^;&|]*@")],
+    only_if=[Tool("Bash"), LambdaCondition(updates_a_bare_plugin)],
     events=Event.PreToolUse,
     tests={
         # Bare name -> warn (the qualifier and scope are missing).
@@ -99,19 +131,25 @@ nudge(
 )
 
 
+FLEET_TOOLS = frozenset(
+    {"capt-hook", "captain-hook", "cc-transcript", "cc-notes", "slop-cop", "cc-guides", "cc-context"}
+)
+
+
+def runs_an_unpinned_fleet_tool(evt: BaseHookEvent) -> bool:
+    for call in evt.command.calls("uvx"):
+        if "UV_EXCLUDE_NEWER" in call.source.args:
+            continue
+        if any(name in FLEET_TOOLS for name in operands(call)):
+            return True
+    return False
+
+
 nudge(
     "Right after a release, a bare `uvx` can serve a stale cached tool env, and the "
     "UV_EXCLUDE_NEWER window hides just-published versions. When you need the fresh release, pin "
     "exact (`uvx <pkg>@X.Y.Z`) or prefix `env -u UV_EXCLUDE_NEWER`.",
-    only_if=[
-        Tool("Bash"),
-        Command(r"\buvx\b"),
-        Command(r"\b(?:capt-hook|captain-hook|cc-transcript|cc-notes|slop-cop|cc-guides|cc-context)\b"),
-    ],
-    skip_if=[
-        Command(r"(?:capt-hook|captain-hook|cc-transcript|cc-notes|slop-cop|cc-guides|cc-context)@"),
-        Command(r"\benv\s+-u\s+UV_EXCLUDE_NEWER\b"),
-    ],
+    only_if=[Tool("Bash"), LambdaCondition(runs_an_unpinned_fleet_tool)],
     events=Event.PreToolUse,
     tests={
         # Bare, unpinned uvx of a fleet tool -> warn.
@@ -131,8 +169,12 @@ nudge(
     "`uv sync` silently no-ops on Rust-only changes in a maturin project — the native extension is "
     "not rebuilt, so you keep running the stale binary. Force the rebuild with "
     "`uv sync --reinstall-package <name>` (the distribution whose Rust you changed).",
-    only_if=[Tool("Bash"), Runs("uv", "sync"), CwdHasFiles("Cargo.toml", "pyproject.toml")],
-    skip_if=[Command(r"--reinstall-package")],
+    only_if=[
+        Tool("Bash"),
+        Runs("uv", "sync"),
+        CwdHasFiles("Cargo.toml", "pyproject.toml"),
+    ],
+    skip_if=[LambdaCondition(lambda evt: any("--reinstall-package" in call.flags for call in evt.command.calls("uv")))],
     events=Event.PreToolUse,
     # Fire path (markers present) is covered by the CwdHasFiles unit test — the inline fixture can't stage marker files.
     tests={
@@ -141,6 +183,97 @@ nudge(
         # No maturin markers at cwd -> silent (the CwdHasFiles gate).
         Input(command="uv sync"): Allow(),
         # Not uv sync -> silent.
+        Input(command="git status"): Allow(),
+    },
+)
+
+
+NAME_TEST_TO_GLOB = {"-name": "--glob", "-iname": "--iglob"}
+FIND_TO_RG_NOTE = (
+    "Rewrote an unbounded `find` to `rg --files`: a name search rooted at $HOME or / walks every "
+    "worktree, node_modules, and build tree on the volume and pins a core for minutes. rg honours "
+    ".gitignore/.ignore and skips hidden files, so it returns the tracked hits in well under a "
+    "second. Need the ignored or hidden ones too? Re-run with `rg --files -uu` or `fd -H -I`."
+)
+FIND_EXEC_BLOCKED = (
+    "BLOCKED: `find -exec` forks one process per hit and traverses ignored trees, so it pins a core "
+    "for minutes on any real checkout. Use `fd` instead: `fd -H -i '<pattern>' <root> -x <cmd>` runs "
+    "the same command per hit, in parallel, honouring .gitignore/.ignore — and `-X` batches them "
+    "into one invocation like `-exec {} +`. To act on content matches rather than names, "
+    "`rg -l '<pattern>' | xargs <cmd>`."
+)
+
+
+def unbounded_root(value: str) -> bool:
+    """Whether a search rooted here walks the whole volume: /, $HOME, /Users, or the worktree pool."""
+    path = value.rstrip("/") or "/"
+    if path == "$HOME" or path.startswith("$HOME/"):
+        path = "~" + path[len("$HOME") :]
+    if path.endswith("/.claude/worktrees"):
+        return True
+    if path in ("/", "~", "/Users"):
+        return True
+    parts = PurePosixPath(path).parts
+    return len(parts) == 3 and parts[:2] == ("/", "Users")
+
+
+def rg_equivalent(command: Command) -> str | None:
+    """``rg --files`` spelling one ``find`` invocation, or None when the shapes do not correspond."""
+    words = command.words[1:]
+    if not words or not unbounded_root(command.args[0]):
+        return None
+    rest = list(zip(command.args[1:], words[1:], strict=True))
+    if rest[:1] and rest[0][0] == "-type":
+        if len(rest) < 2 or rest[1][0] != "f":
+            return None
+        rest = rest[2:]
+    if len(rest) != 2 or (glob := NAME_TEST_TO_GLOB.get(rest[0][0])) is None:
+        return None
+    return f"rg --files {words[0].raw} {glob} {rest[1][1].raw}"
+
+
+def guard_find(evt: PreToolUseEvent, occ: Occurrence, ctx: WalkContext) -> str | Rewritten | HookResult | None:
+    command = occ.command.unwrapped
+    if command.executable != "find":
+        return None
+    if "-exec" in command.args or "-execdir" in command.args:
+        return evt.block(FIND_EXEC_BLOCKED)
+    if not ctx.spliceable or command.env or command.redirects:
+        return None
+    rewritten = rg_equivalent(command)
+    return Rewritten(rewritten, FIND_TO_RG_NOTE) if rewritten else None
+
+
+rewrite_command_occurrences(
+    visit=guard_find,
+    tests={
+        Input(command="find /Users/yasyf -iname '*plugin-workspace-tools*'"): Rewrite(
+            pattern="rg --files /Users/yasyf --iglob '*plugin-workspace-tools*'"
+        ),
+        # The root keeps its source spelling, so ~ still expands and the glob stays quoted.
+        Input(command="find ~ -iname '*.pem'"): Rewrite(pattern="rg --files ~ --iglob '*.pem'"),
+        Input(command="find $HOME -type f -iname foo"): Rewrite(pattern="rg --files $HOME --iglob foo"),
+        Input(command="find /Users/yasyf -name '*.p12'"): Rewrite(pattern="rg --files /Users/yasyf --glob '*.p12'"),
+        Input(command="find ~/.claude/worktrees -iname '*.lock'"): Rewrite(
+            pattern="rg --files ~/.claude/worktrees --iglob '*.lock'"
+        ),
+        # Only the find segment is spliced; its siblings survive byte-for-byte.
+        Input(command="find / -iname 'libssl*' | head -5"): Rewrite(pattern="rg --files / --iglob 'libssl*' | head -5"),
+        Input(command="cd /tmp && find ~ -name Cargo.toml"): Rewrite(
+            pattern="cd /tmp && rg --files ~ --glob Cargo.toml"
+        ),
+        # A scoped root is cheap -> untouched.
+        Input(command="find . -iname '*.ts'"): Allow(),
+        Input(command="find ~/Code/monorepo -iname '*.ts'"): Allow(),
+        Input(command="find api/src -iname '*.ts'"): Allow(),
+        # -type d has no rg --files equivalent -> untouched.
+        Input(command="find ~ -type d -iname build"): Allow(),
+        # -exec blocks at any root, and beats the rewrite.
+        Input(command=r"find . -name '*.pyc' -exec rm {} \;"): Block(),
+        Input(command="find ~ -type f -exec grep -l foo {} +"): Block(),
+        Input(command="find /Users/yasyf -iname '*.log' -exec rm {} +"): Block(),
+        # The word `find` as an argument is not a find call.
+        Input(command="echo find ~ -iname foo"): Allow(),
         Input(command="git status"): Allow(),
     },
 )


### PR DESCRIPTION
## Context

A `find /Users/yasyf -iname '*plugin-workspace-tools*'` launched from an agent
session ran for 27 minutes at 70% of a core before it was killed by hand. On a
machine carrying 663 worktrees and a 2.2 TB data volume, an unbounded `find`
walks every `node_modules`, `buck-out`, and `.git` on disk, and it drags
`fseventsd`, `watchman`, and Spotlight along with it. Load average sat at 8.3
until the process died, then fell to 5.4 within seconds.

cc-context already rewrites a *scoped* `find` to `ccx repo find`, but that
rewrite is repo-relative. A search rooted at `$HOME` is not inside a repo, so
nothing caught the one shape that actually hurts.

## Summary

Adds a `find` guard to the `general` pack and converts the pack's three
remaining regex command matchers to the parsed-command primitives.

The guard is one `rewrite_command_occurrences(visit=...)` walk:

- `find <unbounded-root> [-type f] -name|-iname PAT` rewrites to
  `rg --files <root> --glob|--iglob PAT`.
- Any `find ... -exec` or `-execdir` blocks, pointing at `fd -x` / `-X`.

An unbounded root is `/`, `~`, `$HOME`, `/Users`, `/Users/<someone>`, or the
`.claude/worktrees` pool under any of them. Everything narrower passes through
untouched and still reaches the cc-context rewrite.

The three conversions, all in `general/commands.py`:

| Hook | Was | Now |
|---|---|---|
| `claude plugin update <bare>` | two `Command(...)` regexes | `evt.command.calls("claude")`, argv prefix plus an `operands()` helper that drops flags and their values |
| unpinned `uvx` of a fleet tool | four `Command(...)` regexes | `evt.command.calls("uvx")`, `call.source.args` for the `env -u` carve-out |
| `uv sync` without `--reinstall-package` | `Command(r"--reinstall-package")` | `call.flags` |

## Motivation

Regex over a raw command line is the wrong tool twice over. It fires on text
that no shell would run as a command. `echo find ~ -iname foo` matched the old
pattern and no longer does. It also misses the structure that makes the rewrite
safe. The walk
sees the parsed line, so it handles `sudo`/`env` wrappers through
`command.unwrapped`, skips occurrences carrying redirects or env assignments,
and rewrites one segment of a `;`/`&&`/`|` line while its siblings survive
byte-for-byte.

`rg` honours `.gitignore` and `.ignore` and skips hidden files, which is the
behaviour a name search wants on a developer machine, and it is parallel. On
this checkout `rg --files <repo> -g '*envKey*'` returns in 0.27s where the
equivalent `find` over `$HOME` did not finish in 26 minutes.

<details>
<summary>Details</summary>

The rewrite is built from `Word.raw`, each argument's verbatim source spelling,
never from the dequoted `args`. That is what lets `find ~ -iname '*.pem'` become
`rg --files ~ --iglob '*.pem'` with the tilde still bare, so the shell expands
it, and the glob still quoted, so the shell does not. A `shlex.quote`
reconstruction would emit `'~'` and silently search a directory named `~`.

The rewrite stays conservative where the two tools do not correspond. `-type d`
has no `rg --files` equivalent, so it is left alone instead of answered wrong,
and `-exec` blocks instead of rewriting because its process-per-hit shape has
no faithful one-line translation. The `additionalContext` note names
`rg --files -uu` and `fd -H -I` for the cases where the ignored and hidden hits
are the point.

Verified end to end through `capt-hook run PreToolUse`. The original runaway
command comes back as `rg --files /Users/yasyf --iglob
'*plugin-workspace-tools*'`, `find ~ -iname '*.pem'` keeps its quoting,
`find / -iname 'libssl*' | head -5` rewrites only its first segment,
`find . -name '*.pyc' -exec rm {} \;` denies, and `find api/src -iname '*.ts'`
still falls through to cc-context's `ccx repo find` rewrite. Both converted
nudges still fire on `uvx capt-hook status` and
`claude plugin update cc-context`.

</details>
