### PR TITLE
fix(binrun): probe the helper by absolute path, not through PATH

### DIFF
--- a/captain_hook/bin/capt-hook.binrun
+++ b/captain_hook/bin/capt-hook.binrun
@@ -4,7 +4,7 @@
   "name": "capt-hook",
   "kind": "python-tool",
   "version": {
-    "command": ["/usr/bin/env", "capt-hook-host", "version"],
+    "command": ["/bin/bash", "-c", "exec \"$HOME/Applications/Captain Hook.app/Contents/Helpers/capt-hookd\" version"],
     "json_field": "build"
   },
   "tool": {

--- a/captain_hook/bin/hook.binrun
+++ b/captain_hook/bin/hook.binrun
@@ -4,7 +4,7 @@
   "name": "capt-hook",
   "kind": "python-tool",
   "version": {
-    "command": ["/usr/bin/env", "capt-hook-host", "version"],
+    "command": ["/bin/bash", "-c", "exec \"$HOME/Applications/Captain Hook.app/Contents/Helpers/capt-hookd\" version"],
     "json_field": "build"
   },
   "tool": {

--- a/tests/test_formula_deployment_contract.py
+++ b/tests/test_formula_deployment_contract.py
@@ -71,9 +71,12 @@ def test_signed_controller_stops_only_the_exact_installed_generation() -> None:
         assert forbidden not in source
 
 
-def test_binrun_version_probes_use_the_formula_owned_host() -> None:
-    expected = '["/usr/bin/env", "capt-hook-host", "version"]'
+def test_binrun_version_probes_use_the_stable_signed_host() -> None:
+    expected = (
+        '["/bin/bash", "-c", "exec \\"$HOME/Applications/Captain Hook.app'
+        '/Contents/Helpers/capt-hookd\\" version"]'
+    )
     for name in ("capt-hook.binrun", "hook.binrun"):
         descriptor = (ROOT / "captain_hook/bin" / name).read_text()
         assert expected in descriptor
-        assert "/Applications/Captain Hook.app" not in descriptor
+        assert "capt-hook-host" not in descriptor


### PR DESCRIPTION
## Context

Live Claude Code sessions were failing with:

```
Failed with non-blocking status code: binrun: run version command: exit status 127
```

Exit 127 is "command not found", so this is PATH resolution, not the
10-second `versionCommandTimeout` that produces `signal: killed`. No timeout
was involved and none was changed.

## Summary

Changes the binrun descriptors' version probe from

```json
["/usr/bin/env", "capt-hook-host", "version"]
```

to an absolute exec of the signed helper:

```json
["/bin/bash", "-c", "exec \"$HOME/Applications/Captain Hook.app/Contents/Helpers/capt-hookd\" version"]
```

and adds a deployment-contract assertion so the PATH-dependent form cannot
come back.

## Motivation

daemonkit passes the descriptor array straight to `exec.CommandContext`
without setting `Cmd.Env`, so the version process inherits binrun's
environment (`artifact/descriptor.go:281`). `/usr/bin/env` then searches the
inherited `PATH` for `capt-hook-host`, and daemonkit wraps a miss as
`run version command: exit status 127` (`descriptor.go:285`).

That lookup fails during any Homebrew upgrade of the formula. Homebrew
unlinks the active keg before installing its replacement
(`Library/Homebrew/install.rb:606`), so `/opt/homebrew/bin/capt-hook-host`
does not exist for the length of the install. The observed failures fall
inside exactly that window, while the signed helper under
`$HOME/Applications` stayed present throughout — which is why probing it
directly is the fix rather than a retry.

The same class of failure follows any caller whose `PATH` is degraded, so
taking the probe off `PATH` entirely removes the dependency rather than
narrowing one trigger.

<details>
<summary>Details</summary>

Mise, direnv, and the shell snapshots were each ruled out: `mise doctor`
reports no ignored configs, `mise hook-env -s zsh` returns a populated PATH
even with its cwd deleted, and ten recent snapshots carry populated PATHs
with zero mise/direnv hooks.

Reproduced before the change with `PATH=/tmp/deleted-worktree`:

```
env: capt-hook-host: No such file or directory
env_status=127
binrun: run version command: exit status 127
```

and after the change, the same clobbered PATH exits 0. All 16 live and
source descriptors pass `jq` validation and `binrun -- parse`, and the real
plugin wrapper completes `--help` with `PATH=/usr/bin:/bin`.

Live plugin caches (12.21.0 through 12.22.1, 14 files) were patched in place
so running sessions recover without a restart; backups are under
`~/.claude/backups/captain-hook-binrun-path-20260827T203000Z`. This PR
carries the durable source templates and the regression test.

</details>
