### PR TITLE
[capt-hook] Fix nudge_1ebed8c4 misfiring on consequence-describing prose

### DIFF
--- a/captain_hook/builtin_packs/steering/hooks/steering.py
+++ b/captain_hook/builtin_packs/steering/hooks/steering.py
@@ -63,6 +63,7 @@ nudge(
                         noun=Phrase("issue", "bug", "problem", "error", "failure", "violation", "warning"),
                         verb=Phrase("leave"),
                         tense="prospective",
+                        subject=("unnamed",),
                     ),
                     Clause(
                         noun=Phrase("test"),
@@ -250,6 +251,20 @@ nudge(
         Input(transcript=[T.assistant("The previous issue is beyond the scope of this change.")]): Warn(),
         # f21 word-boundary: "unknown bugs" must not match the "known bug" arm
         Input(transcript=[T.assistant("There are no unknown bugs left outside scope.")]): Allow(),
+        # f22 subject-of-leave: a substantive noun subject (the bug itself, not the
+        # agent) on prospective "leave" describes a consequence, not a dismissal
+        # (misfire 2026-08-24, session 30c00a95)
+        Input(
+            transcript=[
+                T.assistant(
+                    "A mixed batch plus one transient S3 failure would leave a partition "
+                    "looking more recently used than it was, inverting the LRU order this "
+                    "PR exists to establish."
+                )
+            ]
+        ): Allow(),
+        # f22-genuine: pronoun-subject prospective "leave" on the same noun class still warns
+        Input(transcript=[T.assistant("I'll leave that failure unresolved for now.")]): Warn(),
     },
 )
 


### PR DESCRIPTION
## Issue

The Code Stewardship nudge (`steering.steering:nudge_1ebed8c4`) fired on a commit's own
bug-narration text. Claude wrote, in a `TaskStop` context: "A mixed batch (some new ids,
some already mounted) plus one transient S3 failure would leave a partition looking more
recently used than it was, inverting the LRU order this PR exists to establish." — and
the nudge fired with "You appear to be dismissing a pre-existing issue rather than fixing
it." Claude's verbatim complaint (session `30c00a95-efdb-4fb0-b44e-17a0b60181fe`,
2026-08-24): "That hook misfired — it matched my description of the LRU bug, but I fixed
that rather than dismissed it."

The `issue/bug/... + leave` `NlpSignal` clause anchors on any noun in its list plus a
prospective "leave" dependency-related to it, with no subject constraint — so "a failure
would leave a partition looking X" (the bug itself as grammatical subject, describing a
consequence) scores identically to "I'll leave the bug unfixed" (the agent as subject,
declining to act).

## Fix

`captain_hook/builtin_packs/steering/hooks/steering.py` — added `subject=("unnamed",)`
to that `Clause`, so it only fires when the "leave" verb has no substantive noun subject
(imperative/pronoun/passive — "I'll leave...", "Let's leave..."), not when the subject is
the bug/failure/issue itself narrating what it would do. Regression pair added to the
nudge's existing inline test matrix: the misfiring LRU-bug sentence now `Allow()`s, and a
same-noun-class genuine dismissal ("I'll leave that failure unresolved for now.") still
`Warn()`s. All 69 existing tests in the file stay green
(`uv run --project . capt-hook --hooks captain_hook/builtin_packs/steering/hooks test`).

## Example

```text
agent › (TaskStop) "...would leave a partition looking more recently used than it
        was, inverting the LRU order this PR exists to establish."
hook  › (before) ⚠️ You appear to be dismissing a pre-existing issue rather than
        fixing it. ...
hook  › (after)  (silent — no substantive-subject "leave" is a dismissal)
agent › "I'll leave that failure unresolved for now."
hook  › ⚠️ You appear to be dismissing a pre-existing issue rather than fixing it. ...
        (still fires — genuine case unaffected)
```

---
Opened by capt-hook's session reviewer (candidate #1353). Merging adopts the fix; closing
rejects it and the reviewer will not re-propose this candidate.