### PR TITLE
fix(userpath): cache the login PATH, so a slow shell stops costing workers

### DIFF
--- a/captain_hook/util/userpath.py
+++ b/captain_hook/util/userpath.py
@@ -7,18 +7,33 @@ discovery skips a ``claude`` it cannot find and spawnllm's backend selection rai
 ``BackendUnavailable`` in the detached reviewer, while the identical probe from a terminal
 succeeds. The user's login shell is the one authority on where their commands live that a daemon
 can still ask, and it is asked through the passwd database rather than ``$SHELL``, which launchd
-does not set.
+does not set. Asking is also the most expensive thing a worker does before it is ready, so the
+answer is cached and the shell is run only when no fresh record exists.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import pwd
 import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from loguru import logger
+
+from captain_hook.util.fs import atomic_write, read_json
+from captain_hook.util.paths import resolve_cache_dir
 
 # Inside internal/hookd's 10s workerReadinessTimeout: the probe precedes the readiness
 # handshake, so a slower shell costs the daemon a whole worker, not just the user's PATH.
+# Only a worker with no cached answer to fall back to spends this much.
 PROBE_TIMEOUT_SECONDS = 5
+
+REFRESH_TIMEOUT_SECONDS = 1
+
+CACHE_TTL = timedelta(hours=12)
 
 PATH_TAG = "capt-hook-login-path:"
 
@@ -32,8 +47,8 @@ def login_shell() -> str:
     return pwd.getpwuid(os.getuid()).pw_shell
 
 
-def login_path() -> str:
-    """The ``PATH`` the user's login shell exports.
+def login_path(timeout: float) -> str:
+    """The ``PATH`` the user's login shell exports, within *timeout* seconds.
 
     Probes ``printenv PATH`` rather than echoing ``$PATH``: ``printenv`` is an external command, so
     the answer is the exported value in every shell dialect (fish expands a quoted ``$PATH`` to a
@@ -48,7 +63,7 @@ def login_path() -> str:
             [shell, "-l", "-c", f"printenv PATH | sed 's/^/{PATH_TAG}/'"],
             capture_output=True,
             text=True,
-            timeout=PROBE_TIMEOUT_SECONDS,
+            timeout=timeout,
             # An rc file that reads stdin would otherwise consume hookd's length-prefixed hello frame.
             stdin=subprocess.DEVNULL,
         )
@@ -60,6 +75,72 @@ def login_path() -> str:
     if (path := next(tagged, None)) is None:
         raise LoginShellError(f"login shell {shell!r} exported no PATH")
     return path.removeprefix(PATH_TAG)
+
+
+def cache_file() -> Path:
+    return resolve_cache_dir() / "login-path.json"
+
+
+@dataclass(frozen=True)
+class CachedPath:
+    """A ``PATH`` an earlier probe returned, and whether it is still within :data:`CACHE_TTL`."""
+
+    value: str
+    fresh: bool
+
+
+def read_cache(shell: str) -> CachedPath | None:
+    """The cached ``PATH`` for *shell*, or ``None`` when nothing usable is on disk.
+
+    A record naming a different shell is a miss rather than a fallback: the user changed login
+    shells, so the recorded ``PATH`` is another shell's answer and no longer theirs.
+    """
+    if (data := read_json(cache_file())) is None or data.get("shell") != shell:
+        return None
+    try:
+        value, written = str(data["path"]), datetime.fromisoformat(data["at"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return CachedPath(value, datetime.now(UTC) - written < CACHE_TTL)
+
+
+def write_cache(shell: str, value: str) -> None:
+    """Record *value* as *shell*'s exported ``PATH``.
+
+    A cache that cannot be written costs the next worker a probe, never the worker itself, so the
+    failure is logged rather than raised over a ``PATH`` that has already been resolved.
+    """
+    payload = {"shell": shell, "path": value, "at": datetime.now(UTC).isoformat()}
+    try:
+        atomic_write(cache_file(), json.dumps(payload))
+    except OSError:
+        logger.opt(exception=True).debug("login PATH cache write failed")
+
+
+def user_path() -> str:
+    """The user's login ``PATH``, without re-paying for an answer already on disk.
+
+    Sourcing a user's profile is the most expensive thing a worker does before it is ready —
+    measured at 1.5s idle and past :data:`PROBE_TIMEOUT_SECONDS` under a parallel agent fleet,
+    against 0.45s for the worker's whole import graph — and it runs ahead of hookd's readiness
+    handshake, so a shell that answers late costs the daemon a whole worker. The answer changes
+    about as often as the user edits their profile, so a fresh record is adopted without running
+    the shell at all, and a stale one bounds its refresh to :data:`REFRESH_TIMEOUT_SECONDS`
+    because a refresh that fails behind a usable record loses nothing. Raises
+    :class:`LoginShellError` only when the probe fails with no record to fall back to.
+    """
+    shell = login_shell()
+    cached = read_cache(shell)
+    if cached is not None and cached.fresh:
+        return cached.value
+    try:
+        value = login_path(REFRESH_TIMEOUT_SECONDS if cached else PROBE_TIMEOUT_SECONDS)
+    except LoginShellError:
+        if cached is None:
+            raise
+        return cached.value
+    write_cache(shell, value)
+    return value
 
 
 def usable_entries(value: str) -> list[str]:

--- a/captain_hook/worker/__main__.py
+++ b/captain_hook/worker/__main__.py
@@ -16,15 +16,15 @@ def adopt_user_path() -> None:
 
     A worker inherits ``/usr/bin:/bin:/usr/sbin:/sbin`` from the daemon, which hides every CLI the
     product resolves — ``claude`` for the plugin roster, ``claude``/``codex`` for the reviewer's
-    judge — so it asks the user's login shell once instead. A probe that fails is recorded as a
-    fault: the alternative is the state this fixes, where a backend nobody can find looks exactly
-    like a machine with no backend installed.
+    judge — so it takes the user's own ``PATH`` instead, from cache where one is fresh. A probe
+    that fails with nothing cached is recorded as a fault: the alternative is the state this
+    fixes, where a backend nobody can find looks exactly like a machine with no backend installed.
     """
     from captain_hook import faults
-    from captain_hook.util.userpath import LoginShellError, login_path, merged_path
+    from captain_hook.util.userpath import LoginShellError, merged_path, user_path
 
     try:
-        login = login_path()
+        login = user_path()
     except LoginShellError as exc:
         logger.opt(exception=True).error("login shell PATH probe failed; user-installed CLIs stay invisible")
         faults.record("login shell PATH probe", exc)

--- a/tests/test_userpath.py
+++ b/tests/test_userpath.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,6 +14,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 LAUNCHD_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+# A budget for tests that spawn a real shell. The production constant is a policy about hookd's
+# readiness handshake, and an endpoint-security agent can put seconds on any exec of /bin/sh.
+PROBE_BUDGET = 60
 
 
 def tagged(path: str) -> str:
@@ -27,23 +33,21 @@ def fake_shell(tmp_path: Path, body: str, *, exit_code: int = 0) -> str:
 
 def test_login_path_reads_the_exported_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(userpath, "login_shell", lambda: fake_shell(tmp_path, tagged("/opt/tools/bin:/usr/bin")))
-    assert userpath.login_path() == "/opt/tools/bin:/usr/bin"
+    assert userpath.login_path(PROBE_BUDGET) == "/opt/tools/bin:/usr/bin"
 
 
 def test_login_path_survives_a_chatty_login_banner(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # A login shell sources the user's profile, which may print before printenv answers.
     body = f"you have new mail\n{tagged('/opt/tools/bin')}"
     monkeypatch.setattr(userpath, "login_shell", lambda: fake_shell(tmp_path, body))
-    assert userpath.login_path() == "/opt/tools/bin"
+    assert userpath.login_path(PROBE_BUDGET) == "/opt/tools/bin"
 
 
-def test_login_path_survives_logout_chatter_after_the_answer(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_login_path_survives_logout_chatter_after_the_answer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # zsh runs .zlogout after the -c command, so the answer is not the last line either.
     body = f"{tagged('/opt/tools/bin')}session closed\n"
     monkeypatch.setattr(userpath, "login_shell", lambda: fake_shell(tmp_path, body))
-    assert userpath.login_path() == "/opt/tools/bin"
+    assert userpath.login_path(PROBE_BUDGET) == "/opt/tools/bin"
 
 
 def test_login_path_runs_the_real_pipeline_in_a_real_shell(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,7 +55,7 @@ def test_login_path_runs_the_real_pipeline_in_a_real_shell(monkeypatch: pytest.M
     # shell's PATH, so the marker is carried rather than kept in place.
     monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/sh")
     monkeypatch.setenv("PATH", f"/opt/marker/bin:{LAUNCHD_PATH}")
-    entries = userpath.login_path().split(os.pathsep)
+    entries = userpath.login_path(PROBE_BUDGET).split(os.pathsep)
     assert "/opt/marker/bin" in entries
     assert "/usr/bin" in entries
 
@@ -69,7 +73,7 @@ def test_login_path_does_not_read_the_callers_stdin(tmp_path: Path, monkeypatch:
 
     monkeypatch.setattr(userpath, "login_shell", lambda: fake_shell(tmp_path, tagged("/opt/tools/bin")))
     monkeypatch.setattr(subprocess, "run", spy)
-    userpath.login_path()
+    userpath.login_path(PROBE_BUDGET)
     assert seen["stdin"] is subprocess.DEVNULL
 
 
@@ -82,13 +86,13 @@ def test_login_path_raises_when_the_shell_will_not_answer(
 ) -> None:
     monkeypatch.setattr(userpath, "login_shell", lambda: fake_shell(tmp_path, body, exit_code=exit_code))
     with pytest.raises(userpath.LoginShellError):
-        userpath.login_path()
+        userpath.login_path(PROBE_BUDGET)
 
 
 def test_login_path_raises_when_the_shell_cannot_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(userpath, "login_shell", lambda: str(tmp_path / "no-such-shell"))
     with pytest.raises(userpath.LoginShellError, match="could not be probed"):
-        userpath.login_path()
+        userpath.login_path(PROBE_BUDGET)
 
 
 def test_login_shell_comes_from_the_passwd_database(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,6 +135,8 @@ def test_adopt_user_path_replaces_the_launchd_path(tmp_path: Path, monkeypatch: 
     (claude := bindir / "claude").write_text("#!/bin/sh\nexit 0\n")
     claude.chmod(0o755)
     monkeypatch.setenv("PATH", LAUNCHD_PATH)
+    monkeypatch.setattr(userpath, "PROBE_TIMEOUT_SECONDS", PROBE_BUDGET)
+    monkeypatch.setattr(userpath, "cache_file", lambda: tmp_path / "login-path.json")
     monkeypatch.setattr(userpath, "login_shell", lambda: fake_shell(tmp_path, tagged(f"{bindir}:{LAUNCHD_PATH}")))
 
     import shutil
@@ -145,6 +151,7 @@ def test_adopt_user_path_records_a_fault_when_the_probe_fails(tmp_path: Path, mo
     from captain_hook.worker.__main__ import adopt_user_path
 
     monkeypatch.setenv("PATH", LAUNCHD_PATH)
+    monkeypatch.setattr(userpath, "cache_file", lambda: tmp_path / "login-path.json")
     monkeypatch.setattr(userpath, "login_shell", lambda: str(tmp_path / "no-such-shell"))
 
     adopt_user_path()
@@ -184,3 +191,112 @@ def test_update_spawn_is_import_isolated() -> None:
     from captain_hook.update.updater import update_argv
 
     assert update_argv(apply=True)[:4] == [sys.executable, "-P", "-m", "captain_hook"]
+
+
+def recording_probe(value: str, timeouts: list[float]) -> object:
+    """A ``login_path`` stand-in that records the budget each call was given."""
+
+    def probe(timeout: float = userpath.PROBE_TIMEOUT_SECONDS) -> str:
+        timeouts.append(timeout)
+        return value
+
+    return probe
+
+
+def stale(shell: str, path: str) -> str:
+    aged = datetime.now(UTC) - userpath.CACHE_TTL - timedelta(minutes=1)
+    return json.dumps({"shell": shell, "path": path, "at": aged.isoformat()})
+
+
+def test_user_path_probes_once_and_then_reads_the_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    timeouts: list[float] = []
+    monkeypatch.setattr(userpath, "cache_file", lambda: tmp_path / "login-path.json")
+    monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/fish")
+    monkeypatch.setattr(userpath, "login_path", recording_probe("/opt/tools/bin", timeouts))
+
+    assert userpath.user_path() == "/opt/tools/bin"
+    assert userpath.user_path() == "/opt/tools/bin"
+    assert timeouts == [userpath.PROBE_TIMEOUT_SECONDS]
+
+
+def test_user_path_refreshes_a_stale_record_on_the_shorter_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A refresh that fails still has the stale answer behind it, so it may not spend the cold budget.
+    (cache := tmp_path / "login-path.json").write_text(stale("/bin/fish", "/opt/old/bin"))
+    timeouts: list[float] = []
+    monkeypatch.setattr(userpath, "cache_file", lambda: cache)
+    monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/fish")
+    monkeypatch.setattr(userpath, "login_path", recording_probe("/opt/tools/bin", timeouts))
+
+    assert userpath.user_path() == "/opt/tools/bin"
+    assert timeouts == [userpath.REFRESH_TIMEOUT_SECONDS]
+
+
+def test_user_path_falls_back_to_a_stale_record_when_the_refresh_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The failure this fixes: a login shell that answers late blows hookd's readiness handshake, so
+    # a worker that already has an answer must never be lost to one.
+    (cache := tmp_path / "login-path.json").write_text(stale("/bin/fish", "/opt/tools/bin"))
+    monkeypatch.setattr(userpath, "cache_file", lambda: cache)
+    monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/fish")
+    monkeypatch.setattr(
+        userpath, "login_path", lambda timeout=0: (_ for _ in ()).throw(userpath.LoginShellError("late"))
+    )
+
+    assert userpath.user_path() == "/opt/tools/bin"
+
+
+def test_user_path_raises_when_the_probe_fails_with_nothing_cached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(userpath, "cache_file", lambda: tmp_path / "login-path.json")
+    monkeypatch.setattr(userpath, "login_shell", lambda: str(tmp_path / "no-such-shell"))
+    with pytest.raises(userpath.LoginShellError):
+        userpath.user_path()
+
+
+def test_user_path_ignores_a_record_written_by_another_login_shell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fresh = json.dumps({"shell": "/bin/other", "path": "/opt/stale/bin", "at": datetime.now(UTC).isoformat()})
+    (cache := tmp_path / "login-path.json").write_text(fresh)
+    timeouts: list[float] = []
+    monkeypatch.setattr(userpath, "cache_file", lambda: cache)
+    monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/fish")
+    monkeypatch.setattr(userpath, "login_path", recording_probe("/opt/tools/bin", timeouts))
+
+    assert userpath.user_path() == "/opt/tools/bin"
+    assert timeouts == [userpath.PROBE_TIMEOUT_SECONDS]
+
+
+def test_user_path_survives_a_corrupt_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (cache := tmp_path / "login-path.json").write_text("{not json")
+    monkeypatch.setattr(userpath, "cache_file", lambda: cache)
+    monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/fish")
+    monkeypatch.setattr(userpath, "login_path", recording_probe("/opt/tools/bin", []))
+
+    assert userpath.user_path() == "/opt/tools/bin"
+
+
+def test_adopt_user_path_takes_the_cached_answer_without_a_shell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The whole point: a worker that finds a fresh record never runs a login shell before readiness.
+    from captain_hook.worker.__main__ import adopt_user_path
+
+    (bindir := tmp_path / "tools").mkdir()
+    (claude := bindir / "claude").write_text("#!/bin/sh\nexit 0\n")
+    claude.chmod(0o755)
+    record = {"shell": "/bin/fish", "path": f"{bindir}:{LAUNCHD_PATH}", "at": datetime.now(UTC).isoformat()}
+    (cache := tmp_path / "login-path.json").write_text(json.dumps(record))
+    monkeypatch.setenv("PATH", LAUNCHD_PATH)
+    monkeypatch.setattr(userpath, "cache_file", lambda: cache)
+    monkeypatch.setattr(userpath, "login_shell", lambda: "/bin/fish")
+    monkeypatch.setattr(userpath, "login_path", lambda timeout=0: pytest.fail("the login shell was probed"))
+
+    import shutil
+
+    adopt_user_path()
+    assert shutil.which("claude") == str(claude)


### PR DESCRIPTION
## Context

Live sessions on a loaded machine were losing hooks to:

```
captain: handshake Python product worker
captain: read worker frame header: read |0: file already closed
```

The daemon log behind that carried 116 login-shell probe timeouts in a single
hour, and 2,130 `plugin roster unusable; no plugin-shipped pack is loaded`
errors — hooks that ran with no plugin-shipped pack loaded at all.

## Summary

`user_path()` reads the login `PATH` from a cached record and runs the login
shell only when no fresh one exists. `login_path()` now takes its probe budget
as a required argument, so a refresh sitting behind a usable record spends
`REFRESH_TIMEOUT_SECONDS` instead of the cold `PROBE_TIMEOUT_SECONDS`, and a
refresh that fails falls back to the stale record rather than surrendering the
worker's `PATH`. `adopt_user_path()` takes `user_path()` in place of
`login_path()`.

Measured on the machine that reported it: 1,477–1,797 ms cold, **0.3 ms warm**.

## Motivation

`adopt_user_path()` runs before the worker writes its readiness frame, inside
hookd's 10s `workerReadinessTimeout` (`internal/hookd/manager.go:22`). Sourcing
a user's profile is the most expensive thing that happens in that window —
`fish -l -c 'printenv PATH'` measured 1,495 ms per run with the machine idle,
against 450 ms for the worker's entire import graph — and under a parallel agent
fleet it exceeds the 5s `PROBE_TIMEOUT_SECONDS` cap outright. Blow the readiness
budget and hookd tears the child down; `Wait()` closes the stdout pipe, the
pending handshake read returns `file already closed`, and the hook reports the
two lines above.

A worker that survives the timeout is worse than one that does not: the probe
failure is non-fatal, so `PATH` stays launchd-minimal, `which("claude")` returns
`None`, and `enabled_plugins()` raises `PluginListError`. That is the 2,130-error
figure — a hook nobody could see was degraded.

One worker is cached per distinct root, so a machine running many worktrees mints
a worker per root and pays the probe once per spawn. A login `PATH` changes when
the user edits their profile, which is not once per worker, so caching it is the
fix rather than raising a timeout.

<details>
<summary>Details</summary>

The record is keyed on the login shell: a record naming a different shell is a
miss, so changing shells does not serve the old shell's `PATH` for the length of
the TTL. A corrupt or unreadable record is a miss too, and an unwritable cache
costs the next worker a probe rather than failing the one that just resolved a
`PATH`.

`login_path()` losing its default argument also de-flakes the existing suite on
hosts where an endpoint-security agent puts seconds on every `/bin/sh` exec:
the five tests that spawn a real shell were failing intermittently against the
production 5s constant, and now pass an explicit `PROBE_BUDGET`. Verified with
three consecutive green runs of `tests/test_userpath.py` on a host where the old
tests failed 3–5 tests per run.

</details>
