### PR TITLE
fix(nlp): serialize lexicon reads, so dispatch threads stop sharing one sqlite statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- NLP signal matching no longer reads the WordNet lexicon from several dispatch threads at once.
+  `ensure_wn_lexicon` sets `wn.config.allow_multithreading`, which drops Python's same-thread
+  assertion but leaves wn pooling a single process-global sqlite connection; serialized sqlite
+  protects the C handle, not that connection's prepared-statement cache, so two threads running
+  one query reset a statement under the other's step. Sixteen threads reproduced 2521 failures in
+  6400 calls — 1985 `sqlite3.InterfaceError: bad parameter or other API misuse`, and 534
+  `IndexError` short rows, which is the worse half: a row read from a statement already reset
+  looks like a real answer, so a clause could match on lemmas the lexicon never returned. One
+  machine's daemon log carried 62 of the visible failures. Lemma lookups now run one thread at a
+  time and resolve to strings inside the lock, since a `Synset` queries again on attribute access.
+  Lemmas stay cached per phrase, so steady-state dispatch never reaches the lock.
+
+
 ## [12.22.2] - 2026-08-28
 
 ### Fixed

--- a/captain_hook/signals/nlp.py
+++ b/captain_hook/signals/nlp.py
@@ -67,15 +67,7 @@ class ExpandedPhrase(Phrase):
     def lemmas(self) -> tuple[str, ...]:
         from captain_hook.state import RESOURCES
 
-        return tuple(
-            {
-                lemma.replace("_", " ")
-                for term in self.terms
-                for ss in RESOURCES.wn.synsets(term, pos=self.pos)
-                for lemma in ss.lemmas()
-            }
-            | set(self.terms)
-        )
+        return tuple(RESOURCES.wn_lemmas(self.terms, self.pos) | set(self.terms))
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/captain_hook/state.py
+++ b/captain_hook/state.py
@@ -32,6 +32,7 @@ PACK_PACKAGE_PREFIX = "captain_hook._packs"
 class NlpResources:
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._wn_lock = threading.Lock()
 
     @cached_property
     def spacy(self) -> spacy.language.Language:
@@ -68,6 +69,23 @@ class NlpResources:
                 return self.__dict__["wn"]
             ensure_wn_lexicon()
             return wn
+
+    def wn_lemmas(self, terms: tuple[str, ...], pos: str) -> frozenset[str]:
+        # wn pools one process-global sqlite connection, and ensure_wn_lexicon sets
+        # allow_multithreading, which only drops Python's same-thread assertion. Serialized sqlite
+        # protects the C handle, not the connection's prepared-statement cache: two dispatch
+        # threads running one query share a cached statement, and resetting it under another's
+        # step is SQLITE_MISUSE — an InterfaceError, or a short row indistinguishable from an
+        # answer (16 threads: 2521 failures in 6400 calls, 534 of them short rows). Resolved to
+        # strings inside the lock because a Synset queries again on attribute access.
+        module = self.wn
+        with self._wn_lock:
+            return frozenset(
+                lemma.replace("_", " ")
+                for term in terms
+                for synset in module.synsets(term, pos=pos)
+                for lemma in synset.lemmas()
+            )
 
 
 RESOURCES = NlpResources()

--- a/tests/test_state_race.py
+++ b/tests/test_state_race.py
@@ -153,3 +153,66 @@ class TestReserveThenRelease:
         assert execute_hook(entry, edit_evt(), tmp_path) is None
         r = execute_hook(entry, edit_evt(), tmp_path)
         assert r is not None and r.message == "ok"
+
+
+class FakeSynset:
+    def __init__(self, *lemmas: str) -> None:
+        self._lemmas = lemmas
+
+    def lemmas(self) -> tuple[str, ...]:
+        return self._lemmas
+
+
+class FakeWn:
+    """A lexicon stand-in that records how many readers are inside a query at once."""
+
+    def __init__(self) -> None:
+        self.inside = 0
+        self.peak = 0
+
+    def synsets(self, term: str, pos: str) -> list[FakeSynset]:
+        self.inside += 1
+        self.peak = max(self.peak, self.inside)
+        time.sleep(0.002)
+        self.inside -= 1
+        return [FakeSynset(f"{term}_one", f"{term}_two")]
+
+
+class TestWnConnectionRace:
+    def test_lemma_reads_admit_one_thread_at_a_time(self) -> None:
+        """Concurrent lemma reads must never overlap inside the lexicon.
+
+        wn pools one process-global sqlite connection, and `ensure_wn_lexicon` turns off Python's
+        same-thread assertion. Serialized sqlite protects the C handle but not the connection's
+        prepared-statement cache, so two threads running one query is `SQLITE_MISUSE` — an
+        `InterfaceError`, or a short row that reads like a real answer.
+
+        Asserts the observed peak, not the returned lemmas: the unlocked version returns the right
+        answer most of the time, so a result assertion stays green against the bug.
+        """
+        from captain_hook.state import NlpResources
+
+        resources = NlpResources()
+        fake = FakeWn()
+        resources.__dict__["wn"] = fake
+
+        threads = [threading.Thread(target=lambda i=i: resources.wn_lemmas((f"term{i}",), "n")) for i in range(16)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert fake.peak == 1
+
+    def test_lemma_reads_return_every_lemma_and_the_terms(self) -> None:
+        from captain_hook.state import NlpResources
+
+        resources = NlpResources()
+        resources.__dict__["wn"] = FakeWn()
+
+        assert resources.wn_lemmas(("alpha", "beta"), "n") == {
+            "alpha one",
+            "alpha two",
+            "beta one",
+            "beta two",
+        }


### PR DESCRIPTION
## Context

A machine's daemon log carried 62 of these, going back days:

```
sqlite3.InterfaceError: bad parameter or other API misuse
  File ".../wn/_queries.py", line 186, in get_lexicon_extension_bases
    rows = connect().execute(query, {"specifier": lexicon, "depth": depth})
```

reached through `worker/runtime._dispatch` → `signals.matching_signals` →
`nlp.find_lemma_matches` → `Phrase.lemmas`.

## Summary

`NlpResources.wn_lemmas()` resolves a phrase's lemmas under a lock, and
`Phrase.lemmas` calls it instead of walking the lexicon itself. The traversal
resolves to strings inside the lock, because a `Synset` queries again on
attribute access and returning one carries the race back out.

Reproduction, 16 threads × 400 lookups against the real lexicon:

| | before | after |
|---|---|---|
| calls | 6400 | 6400 |
| `InterfaceError: bad parameter or other API misuse` | 1985 | 0 |
| `IndexError: tuple index out of range` | 534 | 0 |
| `InterfaceError: not an error` | 1 | 0 |

## Motivation

`ensure_wn_lexicon` sets `wn.config.allow_multithreading = True` behind a
`sqlite3.threadsafety != 3` guard, on the reasoning that serialized sqlite makes
one shared connection safe for many readers. The guard is real but does not
reach far enough. `wn._db.connect()` pools **one process-global connection** per
database path:

```python
conn = sqlite3.connect(str(dbpath), ..., check_same_thread=not config.allow_multithreading)
pool[dbpath] = conn
```

so `allow_multithreading` only drops Python's same-thread assertion. Serialized
sqlite protects the C handle; it does not protect that connection's
prepared-statement cache. Every dispatch thread runs the same
`get_lexicon_extension_bases` SQL, so they share one cached statement, and one
thread resetting it while another steps is `SQLITE_MISUSE`.

`WorkerService` runs dispatch on a 16-thread pool, which is where the readers
come from.

The `IndexError` is the worse half of the finding and does not appear in the log
at all: a row read from a statement another thread already reset is a short row,
which is not distinguishable from a real answer. A clause could match on lemmas
the lexicon never returned. The 62 logged `InterfaceError`s were the visible
share of a wider fault.

<details>
<summary>Details</summary>

Lemmas are a `functools.cached_property` on a frozen `Phrase`, so each phrase
queries once and is cached for the process's life. That is why the failure was
intermittent rather than constant, and why serializing costs nothing in steady
state — dispatch reaches the lock only on a phrase's first use.

`self._lock` already guards lazy provisioning of the spaCy pipeline and the
lexicon, and it is not reentrant, so `wn_lemmas` resolves `self.wn` before
taking the new `self._wn_lock`.

`TestWnConnectionRace` asserts the observed peak concurrency inside the lexicon,
not the returned lemmas: the unlocked version returns the right answer most of
the time, so a result assertion stays green against the bug. Verified by
reverting the lock — `assert fake.peak == 1` fails with `assert 16 == 1`.

`RESOURCES.spacy` is called from the same thread pool and spaCy makes no
blanket thread-safety guarantee either, but nothing in the logs implicates it
and it shares no state with this path, so it is left alone rather than locked
speculatively.

</details>
