### PR TITLE
docs(authoring-hooks): route bash guards to Runs, not a regex

### DIFF
--- a/captain_hook/skills/authoring-hooks/SKILL.md
+++ b/captain_hook/skills/authoring-hooks/SKILL.md
@@ -65,7 +65,7 @@ has the full decision rules and defaults:
 
 | The rule is... | Primitive |
 |---|---|
-| A guard that must hold on **every** occurrence (safety, correctness) | `hook(..., block=True)`; for bash commands `block_command` |
+| A guard that must hold on **every** occurrence (safety, correctness) | `hook(..., block=True)`; for bash commands `hook(..., only_if=[Tool("Bash"), Runs(...)], block=True)` — `block_command` only when the match is textual (a flag's value, a substring no argv prefix names) |
 | A dangerous-command pattern, advisory | `warn_command` |
 | A done-criterion to check once at stop ("run tests before stopping") | `gate(only_if=[...], skip_if=[RanCommand(...)])` |
 | Advice worth surfacing once per session | `nudge` |

--- a/captain_hook/skills/authoring-hooks/references/pitfalls.md
+++ b/captain_hook/skills/authoring-hooks/references/pitfalls.md
@@ -69,8 +69,12 @@ is born with its own removal ticket attached.
 
 Condition on the narrowest pattern that still captures the correction:
 
-- Anchor command regexes to tokens (`r"git\s+push\s+--force(?!-)"`), not substrings
-  (`"force"`).
+- Match commands structurally: `Runs("git", "stash")` compares exact tokens against the
+  argv prefix of every parsed command in the line, so `echo git stash` and a heredoc
+  body never fire (and `-pl` is not `-p`). A regex is for text no argv prefix names — a
+  flag's value, a substring.
+- When a regex is required, anchor it to tokens
+  (`r"git\s+push\s+--force(?!-)"`), not substrings (`"force"`).
 - Scope file rules with `FilePath(...)` / `SourceEdits(...)` and carve out the benign
   neighbor with `skip_if` (e.g. `TestFile()`).
 - If the rule only bites in one phase (stopping, pushing, editing source), pick the


### PR DESCRIPTION
## Context

An agent following `authoring-hooks` was asked to block Bash commands that use `jobs -p`. It walked the skill's own decision path and produced `block_command(r"jobs\s+-p", ...)`. That regex fires on `echo "use jobs -p to list"` and on a `jobs -p` line inside a heredoc body — neither runs `jobs`. The right primitive was the structural condition `Runs("jobs", "-p")`, which compares exact tokens against the argv prefix of every parsed command in the line and cannot match text in an operand:

```python
hook(
    Event.PreToolUse,
    only_if=[Tool("Bash"), Runs("jobs", "-p")],
    skip_if=[Runs("bash", "-c")],
    block=True,
    message=...,
)
```

The agent only reached `Runs` after the user named it. That is a skill defect, not an agent one: nothing on the path a hook author actually walks offers a structural option for command rules.

## Why the skill routed to a regex

Three places, all on the decision path:

1. **`SKILL.md` Step 2, the primitive table.** The bash-guard cell read `hook(..., block=True); for bash commands block_command`. `block_command` takes a pattern as its first positional argument, so the cell routes every bash guard to a token list or a regex and can never express a structural match.
2. **`references/pitfalls.md` § 5 (over-broad conditions).** The first bullet — "Anchor command regexes to tokens, not substrings" — presupposes a regex for command rules. The very next bullet gives file rules a structural alternative (`FilePath(...)` / `SourceEdits(...)`); command rules got none, which reads as though none exists.
3. **`Runs(` appears exactly once in the skill**, in the generated conditions table of `references/capt-hook-api.md`. That file is where Step 3 sends the author for API lookup, after the primitive is already picked — the one mention sits off the decision.

## Fix

Two surgical edits; no section added or restructured.

- **`SKILL.md:68`** — the bash-guard cell now names `hook(..., only_if=[Tool("Bash"), Runs(...)], block=True)` as the default, with `block_command` demoted to the fallback for a textual match (a flag's value, a substring no argv prefix names).
- **`pitfalls.md` § 5** — a structural-first bullet now precedes the regex-anchoring one: `Runs("git", "stash")` compares exact tokens against the argv prefix of every parsed command in the line, so `echo git stash` and a heredoc body never fire (and `-pl` is not `-p`). The regex-anchoring line stays, reworded as the rule for when a regex is required.

`references/capt-hook-api.md` is untouched — its conditions table is generated (`<!-- gen:conditions -->`) and already documents `Runs` correctly.

## Verification

Docs-only; no code or test change. Read the two diffs: the Step 2 table stays one row per primitive, § 5 stays a bulleted list one bullet longer, and a reader now meets `Runs(...)` before meeting a regex on either path.

https://claude.ai/code/session_01YPTtj43kqK3TJ61WHEZV8b
