### PR TITLE
fix(general): gate unpinned prose spawns and stages, so a missing pin stops running prose on opus

### DIFF
--- a/captain_hook/builtin_packs/general/hooks/models.py
+++ b/captain_hook/builtin_packs/general/hooks/models.py
@@ -122,11 +122,12 @@ class DelegatedSpawn:
 
     tag: str = "delegated_spawn"
     required: bool = True
+    unpinned_note: str = "(none — inherits the session model, fable)"
 
     def content(self, evt: BaseHookEvent) -> str | None:
         if (call := evt.as_input(TaskCall)) is None or not call.prompt:
             return None
-        model = call.model or "(none — inherits the session model, fable)"
+        model = call.model or self.unpinned_note
         return f"model: {model}\nagent_type: {call.agent_type or '(default)'}\nprompt:\n{call.prompt}"
 
 
@@ -146,6 +147,8 @@ class InlineEdit:
 @dataclass(frozen=True, slots=True)
 class ProseSpawn(DelegatedSpawn):
     """Gating context: the pending spawn, present only when its prompt asks to produce a prose artifact."""
+
+    unpinned_note: str = "(none — an unpinned subagent runs opus; subagents never inherit fable)"
 
     def content(self, evt: BaseHookEvent) -> str | None:
         # zero-arg super() breaks under @dataclass(slots=True) — the decorator rebuilds the class
@@ -207,18 +210,17 @@ llm_gate(
         deliverable_rubric=str(Prompt.load("fragments/deliverable_rubric", verdict_attr="block")),
     ),
     message=(
-        "This subagent is pinned to a non-fable model but its deliverable is prose/writing work. "
+        "This subagent's deliverable is prose/writing work, but it will not run on fable. "
         "{reasoning} All writing — docs, READMEs, release notes, any user-facing text — routes "
-        "to fable: drop model to inherit the session model, or pass model='fable'. "
+        "to fable, and a spawn naming no model runs opus rather than inheriting the session "
+        "model: pass model='fable' explicitly. "
         "See CLAUDE.md § Plan Execution & Orchestration (Models)."
     ),
     contexts=[ProseSpawn()],
     events=Event.PreToolUse,
-    only_if=[
-        Tool("Agent|Task"),
-        ToolInput("model", r"(?i)\b(haiku|sonnet|opus)\b"),
-    ],
+    only_if=[Tool("Agent|Task")],
     skip_if=[
+        ToolInput("model", r"(?i)\bfable\b"),
         ToolInput("prompt", r"(?i)\b(classif|label|tag|categoriz|count|extract|mechanical)"),
         Agent("Explore|claude-code-guide"),
     ],
@@ -230,9 +232,11 @@ llm_gate(
         Input(model="opus", prompt="draft the release notes for v2"): Block(),
         Input(model="haiku", prompt="update the CHANGELOG entry for the fix"): Block(),
         Input(model="fable", prompt="write the README quickstart"): Allow(),
-        Input(prompt="write the README quickstart"): Allow(),
+        Input(prompt="write the README quickstart"): Block(),
+        Input(prompt="draft the release notes for v2"): Block(),
         Input(model="sonnet", prompt="review the README for factual errors"): Allow(),
         Input(model="sonnet", prompt="update the retry backoff config"): Allow(),
+        Input(prompt="update the retry backoff config"): Allow(),
         Input(model="haiku", prompt="label each README section with its Diataxis mode"): Allow(),
         Input(agent_type="Explore", model="sonnet", prompt="find where the README quickstart is written"): Allow(),
         Input(agent_type="claude-code-guide", model="sonnet", prompt="explain how the docs get updated"): Allow(),
@@ -492,28 +496,27 @@ llm_nudge(
         deliverable_rubric=DELIVERABLE_NUDGE_RUBRIC,
     ),
     message=(
-        "This workflow script pins a non-fable model on a stage whose deliverable is prose. {reasoning} "
-        "All writing — docs, READMEs, release notes, any user-facing text — routes to fable: inherit the "
-        "session model or pin model: 'fable' on that stage. "
+        "This workflow script runs a stage whose deliverable is prose off fable. {reasoning} "
+        "All writing — docs, READMEs, release notes, any user-facing text — routes to fable, and a "
+        "stage with no model pin runs opus rather than inheriting the session model: pin "
+        "model: 'fable' on that stage. "
         "See CLAUDE.md § Plan Execution & Orchestration (Models)."
     ),
     contexts=[ProseWorkflowScript()],
     events=Event.PreToolUse,
-    only_if=[
-        Tool("Workflow"),
-        WorkflowScript(model="haiku|sonnet|opus"),
-    ],
+    only_if=[Tool("Workflow")],
     max_fires=2,
     max_context=16_000,
     agent=False,
     transcript=False,
     tests={
         Input(script="steps:\n  - agent: write the README intro\n    model: 'sonnet'\n"): Warn(pattern="fable"),
-        Input(script="steps:\n  - agent: write the README intro\n    model: 'fable'\n"): Allow(),
+        Input(script="steps:\n  - agent: write the README intro\n"): Warn(pattern="fable"),
+        Input(script="steps:\n  - agent: write the README intro\n    model: 'fable'\n", llm={"fire": False}): Allow(),
         Input(script="steps:\n  - agent: fix the retry backoff\n    model: 'sonnet'\n"): Allow(),
         Input(script="agent('Audit docs/architecture.md for stale claims', {model: 'opus'})"): Allow(),
         Input(
-            script="agent('recon the module map', {model: 'sonnet'})\n// all prose stays with the main agent on fable\n"
+            script="agent('recon the module map', {model: 'sonnet'})\n// every prose stage is pinned to fable\n"
         ): Allow(),
         Input(
             script="agent('Fix the import in cli.py. Do NOT edit CHANGELOG.md — a sibling owns it', {model: 'opus'})",

--- a/captain_hook/builtin_packs/general/hooks/prompts/fragments/workflow_script_header.md
+++ b/captain_hook/builtin_packs/general/hooks/prompts/fragments/workflow_script_header.md
@@ -1,8 +1,8 @@
 Its header quotes verbatim excerpts around the script's model pins; … marks
 elided text within an excerpt. A header reading "excerpts around every model
-pin in this script" is complete: a stage not quoted there carries no pin and
-inherits the session model — in this project fable, already correctly routed
-whatever it writes. A header reading "excerpts around the first model pins in
-this script" and ending in a "… [+N more model pins not excerpted]" line was
-capped: absence from that header no longer proves a stage is unpinned — check
-the script source before concluding a stage inherits fable.
+pin in this script" is complete: a stage not quoted there carries no pin and so
+runs opus — workflow stages never inherit fable, so an unpinned stage is
+opus-routed, not fable-routed. A header reading "excerpts around the first model
+pins in this script" and ending in a "… [+N more model pins not excerpted]" line
+was capped: absence from that header no longer proves a stage is unpinned — check
+the script source before concluding a stage carries no pin.

--- a/captain_hook/builtin_packs/general/hooks/prompts/models/prose_spawn_gate.md
+++ b/captain_hook/builtin_packs/general/hooks/prompts/models/prose_spawn_gate.md
@@ -1,5 +1,5 @@
-Decide whether this delegated subagent call pins a non-fable model on work whose
-deliverable is prose.
+Decide whether this delegated subagent call runs work whose deliverable is prose
+on anything but fable — a non-fable pin, or no pin at all.
 
 <delegated_spawn> holds the pending Agent/Task call: its model pin, agent type, and
 prompt, ending with the sentences a clause prefilter matched — each asks a writing
@@ -8,9 +8,12 @@ screened out. Your job is precision: is a prose artifact what this subagent is
 asked to PRODUCE?
 
 The Models rubric: all writing a user reads — READMEs, docs, changelogs, release
-notes, blog posts, PR descriptions, any user-facing text — routes to fable. Work
-that merely mentions a prose file — as a constraint ("do NOT touch the docs"), as
-reading material, as the subject of recon or review — is not prose work.
+notes, blog posts, PR descriptions, any user-facing text — routes to fable, and it
+gets there only through an explicit model pin: a subagent naming no model runs
+opus, never the session model, so a missing pin misroutes prose exactly as a wrong
+pin does. Work that merely mentions a prose file — as a constraint ("do NOT touch
+the docs"), as reading material, as the subject of recon or review — is not prose
+work.
 
 {deliverable_rubric}
 
@@ -28,9 +31,17 @@ The deliverable is README prose on a non-fable pin.
 model: opus — Update CHANGELOG.md with an entry for the retry fix.
 The subagent itself writes the changelog prose.
 </example>
+<example block="true">
+model: (none — an unpinned subagent runs opus; subagents never inherit fable) — Draft the release notes for v2.
+Release-notes prose with no pin, so it runs opus; prose needs model='fable' spelled out.
+</example>
 <example block="false">
 model: opus — Fix the failing test in cli.py. Do NOT edit CHANGELOG.md — a sibling owns it.
 CHANGELOG is a constraint, not the deliverable; this is code work.
+</example>
+<example block="false">
+model: (none — an unpinned subagent runs opus; subagents never inherit fable) — Fix the retry backoff in client.py and update the failing test.
+Code work with no prose deliverable; the missing pin routes it to opus, which is right for code.
 </example>
 <example block="false">
 model: sonnet — Explore the cc-interact building blocks and report where the docs pipeline is written.

--- a/captain_hook/builtin_packs/general/hooks/prompts/models/prose_workflow_nudge.md
+++ b/captain_hook/builtin_packs/general/hooks/prompts/models/prose_workflow_nudge.md
@@ -1,26 +1,28 @@
-Decide whether this workflow script pins a non-fable model on a stage whose
-deliverable is prose.
+Decide whether this workflow script runs a stage whose deliverable is prose on
+anything but fable — a non-fable pin, or no pin at all.
 
 <workflow_script> holds the pending Workflow call's script source.
 {workflow_script_header}
 The header is followed by the sentences a clause prefilter matched: each asks a
 writing verb of a prose artifact, with negated asks ("do NOT edit CHANGELOG.md")
-already screened out. Your job is precision: does a PINNED stage have prose as its
-own deliverable?
+already screened out. Your job is precision: does any stage have prose as its own
+deliverable, and would that stage run off fable?
 
 The Models rubric: all writing a user reads — READMEs, docs, changelogs, release
-notes, blog posts, announcements, any user-facing text — routes to fable. A stage's
-deliverable is prose when its agent() prompt asks it to write, draft, revise, or
-polish such an artifact.
+notes, blog posts, announcements, any user-facing text — routes to fable, and it
+gets there only through an explicit pin: a stage carrying no model pin runs opus,
+never the session model, so an unpinned prose stage is misrouted exactly as an
+opus-pinned one is. A stage's deliverable is prose when its agent() prompt asks it
+to write, draft, revise, or polish such an artifact.
 
 {deliverable_rubric}
 
-Set fire=true only when at least one agent() call both pins haiku/sonnet/opus and
-has prose as its deliverable. A prose stage with no pin of its own is fine, even
-when other stages pin opus. A prose keyword that appears as a constraint ("do NOT
-edit CHANGELOG.md"), an ownership note, a file the stage merely reads, a
-meta.description, or prose the orchestrator script assembles itself outside any
-pinned agent() call is not that stage's deliverable: fire=false. When uncertain,
+Set fire=true when at least one agent() call has prose as its deliverable and does
+not pin model: 'fable' — whether it pins haiku/sonnet/opus or pins nothing at all.
+Only an explicit fable pin on that stage clears it. A prose keyword that appears as
+a constraint ("do NOT edit CHANGELOG.md"), an ownership note, a file the stage
+merely reads, a meta.description, or prose the orchestrator script assembles itself
+outside any agent() call is not a stage's deliverable: fire=false. When uncertain,
 fire=false — a false alarm teaches the agent to ignore this nudge. Keep reasoning
 under 40 words and name the offending stage.
 
@@ -37,10 +39,14 @@ A docs page is user-facing prose; the pin is non-fable.
 agent('Fix the failing import in cli.py. Do NOT edit CHANGELOG.md — a sibling owns it', {model: 'opus'})
 CHANGELOG appears only as a constraint; the deliverable is a code fix.
 </example>
-<example fire="false">
+<example fire="true">
 agent('Fix the CLI error handling', {label: 'fix:cli', model: 'opus'}) alongside
 agent('Reword the troubleshooting guide and CHANGELOG bullet', {label: 'fix:docs'})
-The prose stage carries no pin — it inherits fable; the opus pin is on code.
+The prose stage carries no pin, so it runs opus; prose needs model: 'fable' spelled out.
+</example>
+<example fire="false">
+agent('Rewrite the quickstart section of the README', {model: 'fable'})
+The prose stage pins fable — routed right.
 </example>
 <example fire="false">
 meta: {description: 'verify the doc claims against actual behavior'}, then agent('run the test matrix', {model: 'opus'})

--- a/captain_hook/builtin_packs/general/hooks/prompts/models/review_routing_workflow_nudge.md
+++ b/captain_hook/builtin_packs/general/hooks/prompts/models/review_routing_workflow_nudge.md
@@ -21,7 +21,7 @@ security-sensitive implementation, which is not review.
 {deliverable_rubric}
 
 Set fire=true when at least one review or diagnosis stage would run on a Claude
-model: unpinned (inherits fable), pinned 'fable', or pinned to any model with a
+model: unpinned (which runs opus), pinned 'fable', or pinned to any model with a
 prompt that runs the codex skill itself — the retired wrapper stays fire=true
 wherever it appears, fallback branches included. Stages routed via agentType
 'codex:codex-wrapper', synthesis stages, and design judgment are routed right:
@@ -42,11 +42,11 @@ ignore this nudge. Keep reasoning under 40 words and name the offending stage.
 <examples>
 <example fire="true">
 agent(`Sweep the diff for go-correctness issues; return findings as JSON`)
-An unpinned finder inherits fable; finder sweeps are the codex-wrapper agent's lane.
+An unpinned finder runs opus; finder sweeps are the codex-wrapper agent's lane.
 </example>
 <example fire="true">
 findings.map(f => agent(`Adversarially refute: ${f.title}`, {effort: 'max'}))
-Refuters over code findings inherit fable — route them via agentType 'codex:codex-wrapper'.
+Refuters over code findings run on a Claude model — route them via agentType 'codex:codex-wrapper'.
 </example>
 <example fire="true">
 agent('Write a self-contained codex prompt reviewing this diff, then run the codex skill', {model: 'sonnet', effort: 'low'})
@@ -78,6 +78,6 @@ An unconditional fable review with no codex-wrapper attempt and no declared esca
 </example>
 <example fire="true">
 agent(`Audit the auth flow for injection and session-fixation issues; return findings as JSON`)
-An unpinned security audit inherits fable; security review/audit is the codex-wrapper agent's lane.
+An unpinned security audit runs opus; security review/audit is the codex-wrapper agent's lane.
 </example>
 </examples>

--- a/captain_hook/contexts.py
+++ b/captain_hook/contexts.py
@@ -270,7 +270,7 @@ class WorkflowScriptSource:
             f"excerpts around the first model pins in this script (+{pins.dropped} more noted below; "
             "a stage not quoted here is NOT necessarily unpinned):"
             if pins.capped
-            else "excerpts around every model pin in this script (a stage not quoted here inherits the session model):"
+            else "excerpts around every model pin in this script (a stage not quoted here carries no pin):"
         )
         return f"{lead}\n{pins.block('model pins')}", source
 

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -444,7 +444,7 @@ class TestWorkflowScriptSource:
         assert content is not None
         assert "more model pins not excerpted" not in content
         assert content.startswith(
-            "excerpts around every model pin in this script (a stage not quoted here inherits the session model):"
+            "excerpts around every model pin in this script (a stage not quoted here carries no pin):"
         )
 
     def test_no_pins_says_none(self) -> None:


### PR DESCRIPTION
## Context

The prose guards in the `general` pack were built on a premise the routing doctrine no longer holds: that a delegated lane naming no model inherits the session model, fable. That is only true when the root session itself runs fable, and a subagent or workflow stage that names no `model` runs opus regardless. The doctrine now routes prose through an explicit `model: 'fable'` pin, so a spawn or stage with no pin at all misroutes prose exactly as an opus pin does.

Both guards only caught the wrong pin. `prose_spawn_gate` required `ToolInput("model", haiku|sonnet|opus)` and `prose_workflow_nudge` required `WorkflowScript(model=…)`, so an unpinned prose lane passed through silently and ran on opus. Worse, the gate's own context told the judge the opposite: the unpinned line read `(none — inherits the session model, fable)`, and the shared workflow header fragment said an unquoted stage "inherits the session model — in this project fable, already correctly routed whatever it writes". Widening the trigger alone would have had the LLM overrule the new prompt with that stale premise.

## Summary

- **`prose_spawn_gate`** (llm_gate) fires on every `Agent`/`Task` spawn whose prompt trips the prose prefilter; `skip_if` gained `ToolInput("model", fable)` and `only_if` dropped the `haiku|sonnet|opus` requirement. This is the shape the sibling `writing_docs_spawn_nudge` already had: every spawn, behind the same `ProseSpawn` prefilter. The prompt and block message now say a missing pin misroutes prose as a wrong pin does, and tell the caller to pass `model='fable'` rather than "drop model to inherit the session model".
- **`prose_workflow_nudge`** (llm_nudge) dropped `WorkflowScript(model=…)` from `only_if`; the LLM decides per stage, and only an explicit `model: 'fable'` on the prose stage clears it. There is deliberately no per-script fable skip: one fable-pinned stage would mask an unpinned prose stage elsewhere in the same script.
- **`ProseSpawn`** overrides a new `DelegatedSpawn.unpinned_note` field so the gate's context reads `(none — an unpinned subagent runs opus; subagents never inherit fable)`. The default is unchanged, so the other spawn hooks see the same context as before.
- **`fragments/workflow_script_header.md`** now says an unpinned stage runs opus. `review_routing_workflow_nudge.md` consumes that fragment, so its four "inherits fable" parentheticals were corrected to match; its verdicts do not change, because an unpinned review stage is still a Claude-model stage that belongs on `codex:codex-wrapper`.
- **`contexts.py`**: the `WorkflowScriptSource` uncapped header lead reads "a stage not quoted here carries no pin" instead of "inherits the session model"; `tests/test_contexts.py` asserts the new string.

## Verification

Inline tests: the unpinned prose spawns (`write the README quickstart`, `draft the release notes for v2`) flipped from `Allow()` to `Block()`; an unpinned prose workflow stage was added as a `Warn(pattern="fable")` case; and two regression `Allow()`s pin the boundary — an unpinned *code* spawn (`update the retry backoff config`, which the prefilter keeps out of the gate) and a fable-pinned prose stage. New prompt examples cover the same three shapes.

`uv run pytest tests/test_builtin_inline.py tests/test_contexts.py tests/test_packs.py` — 166 passed. CI runs the full suite on this push.

## Follow-up

The spawn-side `implementation_spawn_nudge` and `review_routing_spawn_nudge` still describe an unpinned spawn as inheriting fable, through the unchanged `DelegatedSpawn.unpinned_note` default. Correcting that wording means revisiting when those two nudges should fire at all, so it is left out of this PR.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
