### PR TITLE
fix(worker): key the log on the pid when the root is gone, so a deleted workspace stops taking the host down

### DIFF
--- a/captain_hook/worker/__main__.py
+++ b/captain_hook/worker/__main__.py
@@ -41,9 +41,15 @@ def worker_log_key(build: str) -> str:
     concurrent same-build workers keyed on the build alone would rotate one shared log file —
     loguru's rotation is per-process, and one worker's rename strands the others' handles on
     the unlinked inode.
+
+    A root deleted under a live session leaves the worker with an unresolvable cwd; the pid
+    stands in for it, keeping such workers on separate log files rather than killing dispatch.
     """
-    root = hashlib.sha256(os.path.realpath(os.getcwd()).encode("utf-8", "surrogatepass")).hexdigest()[:16]
-    return f"{build}-{root}"
+    try:
+        root = os.path.realpath(os.getcwd())
+    except FileNotFoundError:
+        root = f"deleted-root-{os.getpid()}"
+    return f"{build}-{hashlib.sha256(root.encode('utf-8', 'surrogatepass')).hexdigest()[:16]}"
 
 
 def main() -> None:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -196,3 +196,29 @@ def test_workers_in_different_roots_write_different_daemon_logs(tmp_path: Path) 
         assert worker.returncode == 0, worker.stderr.decode()
 
     assert len(list(logs.glob("daemon-*.log"))) == 2
+
+
+def test_worker_survives_a_root_deleted_under_it(tmp_path: Path) -> None:
+    """PIN: an Orca workspace deleted under a live session leaves the worker with no cwd.
+
+    ``worker_log_key`` resolved the root through ``os.getcwd()``, which raises
+    ``FileNotFoundError`` once that directory is gone, so every dispatch from such a session
+    killed its worker before ``WorkerService`` ever ran — observed 2026-09-02 crash-looping
+    against ``~/.orca/workspaces/monorepo-old``, which took the host's socket down with it.
+    """
+    import os
+    import subprocess
+
+    root = tmp_path / "gone"
+    root.mkdir()
+    logs = tmp_path / "logs"
+    worker = subprocess.run(
+        ["/bin/sh", "-c", 'cd "$1" && rmdir "$1" && exec "$0" -m captain_hook.worker', sys.executable, str(root)],
+        input=b"",
+        capture_output=True,
+        env={**os.environ, "CAPTAIN_HOOK_LOG_DIR": str(logs)},
+        timeout=180,
+    )
+
+    assert worker.returncode == 0, worker.stderr.decode()
+    assert len(list(logs.glob("daemon-*.log"))) == 1


### PR DESCRIPTION
## Context

Every Claude Code prompt on a machine was failing its Stop hook with:

```
captain: signed host is not installed and ready; run 'capt-hook helper install': captain: daemon unavailable
no daemon is listening: dial unix ~/.daemonkit/a/com.yasyf.captain-hook.host.v1/daemon.sock: no such file or directory
```

`capt-hookd` was alive (pid 10071 plus three Python workers) but its socket did not exist. `capt-hookd serve` refused to start a replacement with "daemon already serving", since the pids in `daemon.records` were running, and `launchctl list` showed `-` for the job's pid, so launchd did not own the process and `launchctl kickstart -k` did not replace it. Killing the process group and kickstarting restored the socket.

`~/Library/Caches/captain-hook/host-v1/capt-hookd.log` held one traceback on repeat, and a live one arrived while diagnosing: a dispatch running `capt-hookd run --event PreToolUse --root ~/.orca/workspaces/monorepo-old/monorepo-old/flatworm --cwd <same>`, a directory that no longer exists.

## Summary

`worker_log_key` resolved the project root through `os.path.realpath(os.getcwd())`. `os.getcwd()` raises `FileNotFoundError` once the process's cwd has been deleted, and the call sits in `main()` before `WorkerService` starts, so every dispatch from a session whose root was gone killed its worker at startup. The crash-looping workers took the host's socket down with them, which is why the failure surfaced as "daemon unavailable" rather than as a worker error.

The fix keeps the per-root key the docstring's rotation invariant depends on (loguru rotation is per-process, and same-build workers sharing one file strand each other's handles on the unlinked inode) and substitutes a pid-derived key when the cwd is unresolvable. Workers with a deleted root stay on separate log files instead of dying.

Orca deletes workspace directories under sessions that are still alive and still firing hooks, so this is a recurring condition, not a one-off. That is why the worker tolerates it rather than crashing.

## Verification

`tests/test_worker_runtime.py::test_worker_survives_a_root_deleted_under_it` spawns the worker from a directory deleted between `cd` and `exec`. It fails on the unfixed code with the production traceback (`FileNotFoundError` at `worker_log_key`) and passes with the fix; the two existing daemon-log tests still pass. CI runs the full suite on this push.

## Follow-up

Two related weaknesses this PR does not address, each worth its own issue:

1. `capt-hookd serve` treats a live pid in `daemon.records` as proof the daemon is serving, with no check that the socket exists. That is the state that made the outage unrecoverable without a manual kill.
2. `capt-hookd run` spawns a worker for a `--root` that no longer exists rather than failing fast.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
