### PR TITLE
fix(client): spell --cwd against the root when the directory is gone, so a deleted workspace stops failing its hooks

### DIFF
--- a/capt_hook_client/client.py
+++ b/capt_hook_client/client.py
@@ -18,13 +18,25 @@ HOST = os.path.join(
 DIST_NAME = "capt-hook"
 
 
+def _cwd() -> str:
+    """The invocation's directory, or the filesystem root once that directory is gone.
+
+    A workspace deleted under a live session leaves every later hook with an unresolvable
+    cwd, and ``os.getcwd()`` raises there — failing the dispatch before it is even spelled.
+    """
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        return os.path.sep
+
+
 def main() -> NoReturn:
     """Translate the one hook-event grammar and exec the fixed Go client."""
     parsed = _parse_run(sys.argv[1:])
     if parsed is None:
         _die("usage: hook [--root ROOT] run EVENT [--async]")
     root, event, async_ = parsed
-    cwd = os.getcwd()
+    cwd = _cwd()
     argv = [
         HOST,
         "run",

--- a/tests/test_signed_host_client.py
+++ b/tests/test_signed_host_client.py
@@ -10,6 +10,41 @@ import pytest
 from capt_hook_client import client
 
 
+def test_deleted_cwd_still_spells_a_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PIN: a workspace deleted under a live session leaves every later hook with no cwd.
+
+    ``os.getcwd()`` raises ``FileNotFoundError`` there, which failed the dispatch before it was
+    spelled — observed 2026-09-02 against a deleted ``~/.orca/workspaces`` root, one layer above
+    the worker crash fixed in the same release.
+    """
+
+    def gone() -> Never:
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(sys, "argv", ["hook", "run", "Stop"])
+    monkeypatch.setattr(os, "getcwd", gone)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("FACTORY_PROJECT_DIR", raising=False)
+
+    def version(_name: str) -> str:
+        return "12.9.1"
+
+    monkeypatch.setattr(importlib.metadata, "version", version)
+    captured: list[object] = []
+
+    def execv(path: str, argv: list[str]) -> None:
+        captured.extend((path, argv))
+        raise RuntimeError("exec")
+
+    monkeypatch.setattr(os, "execv", execv)
+    with pytest.raises(RuntimeError, match="exec"):
+        client.main()
+    argv = captured[1]
+    assert isinstance(argv, list)
+    assert argv[argv.index("--cwd") + 1] == os.path.sep
+    assert argv[argv.index("--root") + 1] == os.path.sep
+
+
 def test_run_execs_fixed_host_with_exact_product_identity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["hook", "--root", "/spelled/root", "run", "PreToolUse", "--async"])
     monkeypatch.setattr(os, "getcwd", lambda: "/request/cwd")


### PR DESCRIPTION
## Context

#29 (v12.23.2) fixed `worker_log_key` in `captain_hook/worker/__main__.py`, where `os.getcwd()` raised `FileNotFoundError` for a worker whose root had been deleted. Verifying that fix on the machine, with a real dispatch from a deleted directory, surfaced the same condition one layer up, in the client shim. Verbatim from the live 12.23.2 tool env:

```
Traceback (most recent call last):
  File "/Users/yasyf/.daemonkit/tools/capt-hook/12.23.2/capt-hook/bin/hook", line 10, in <module>
    sys.exit(main())
  File ".../capt_hook_client/client.py", line 27, in main
    cwd = os.getcwd()
FileNotFoundError: [Errno 2] No such file or directory
```

`capt_hook_client/client.py` read `os.getcwd()` to spell `--cwd` for the signed host, and `--root` too when neither `CLAUDE_PROJECT_DIR` nor `FACTORY_PROJECT_DIR` is set. Orca deletes workspace directories under sessions that are still alive and still firing hooks, so every later hook from such a session starts with an unresolvable cwd, and the dispatch failed before it was spelled.

The blast radius is why this is a follow-up rather than part of #29. The worker crash killed the shared worker and took the host's socket down for every session on the machine; that was the outage. This one fails only the single hook invocation that has no cwd. Confirmed on the machine: with v12.23.2 deployed, a dispatch from a deleted directory still failed, but `daemon.sock` survived it.

## Summary

`_cwd()` returns `os.getcwd()`, or `os.path.sep` once that directory is gone, and `main()` spells `--cwd` from it. The dispatch is spelled against a path that exists instead of failing to be spelled at all.

`--root`'s precedence is unchanged: an explicit `--root`, then `CLAUDE_PROJECT_DIR`, then `FACTORY_PROJECT_DIR`, then the cwd.

## Verification

New `tests/test_signed_host_client.py::test_deleted_cwd_still_spells_a_dispatch` monkeypatches `os.getcwd` to raise `FileNotFoundError`, clears both project-dir env vars, and asserts the exec'd argv carries `/` for both `--cwd` and `--root`. The whole file passes (9 tests). The unfixed behavior needs no synthetic reproduction: the traceback above is from the released 12.23.2 build running on the machine. CI runs the full suite on this push.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
