### PR TITLE
fix(client): spell --root from PWD when the directory is gone, so a deleted workspace stops walking the whole filesystem

### DIFF
--- a/capt_hook_client/client.py
+++ b/capt_hook_client/client.py
@@ -19,15 +19,17 @@ DIST_NAME = "capt-hook"
 
 
 def _cwd() -> str:
-    """The invocation's directory, or the filesystem root once that directory is gone.
+    """The invocation's directory, named by the shell once the directory itself is gone.
 
     A workspace deleted under a live session leaves every later hook with an unresolvable
     cwd, and ``os.getcwd()`` raises there — failing the dispatch before it is even spelled.
+    ``PWD`` still carries the path, which keeps the dispatch truthful and inert: a root that
+    does not exist walks to nothing, where the filesystem root would walk the whole machine.
     """
     try:
         return os.getcwd()
     except FileNotFoundError:
-        return os.path.sep
+        return os.environ.get("PWD") or os.path.sep
 
 
 def main() -> NoReturn:

--- a/captain_hook/packs/manager.py
+++ b/captain_hook/packs/manager.py
@@ -224,8 +224,15 @@ def resolve_builtin(name: str) -> ResolvedPack:
 
 
 def gitignore_lines(path: Path) -> list[str]:
-    """The non-comment, non-blank pattern lines of a ``.gitignore``, or ``[]`` when it is absent."""
-    if not path.is_file():
+    """The non-comment, non-blank pattern lines of a ``.gitignore``, or ``[]`` when it is unreadable.
+
+    A walk root wide enough to reach a synthetic path — macOS mounts ``/.resolve`` under ``/`` —
+    stats it with ``EINVAL`` rather than a missing-file error, which ``is_file`` propagates.
+    """
+    try:
+        if not path.is_file():
+            return []
+    except OSError:
         return []
     return [line for raw in path.read_text().splitlines() if (line := raw.strip()) and not line.startswith("#")]
 

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -410,3 +410,17 @@ def test_steering_deferral_gate_skips_in_plan_mode() -> None:
         if h.spec.events & (Event.Stop | Event.SubagentStop) and InPlanMode() in h.spec.skip_if
     )
     assert gate.spec.skip_if == (Waiting(), InPlanMode())
+
+
+def test_gitignore_lines_survives_an_unstattable_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PIN: a walk root wide enough to reach a synthetic path stats it with EINVAL, not ENOENT.
+
+    ``detect_languages`` rooted at ``/`` reached macOS's ``/.resolve`` and died on the
+    ``OSError`` ``is_file`` propagates, taking the whole dispatch with it (2026-09-02).
+    """
+
+    def einval(self: Path, *, follow_symlinks: bool = True) -> bool:
+        raise OSError(22, "Invalid argument")
+
+    monkeypatch.setattr(Path, "is_file", einval)
+    assert manager.gitignore_lines(Path("/.resolve/.gitignore")) == []

--- a/tests/test_signed_host_client.py
+++ b/tests/test_signed_host_client.py
@@ -25,6 +25,7 @@ def test_deleted_cwd_still_spells_a_dispatch(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(os, "getcwd", gone)
     monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
     monkeypatch.delenv("FACTORY_PROJECT_DIR", raising=False)
+    monkeypatch.setenv("PWD", "/deleted/workspace")
 
     def version(_name: str) -> str:
         return "12.9.1"
@@ -41,8 +42,19 @@ def test_deleted_cwd_still_spells_a_dispatch(monkeypatch: pytest.MonkeyPatch) ->
         client.main()
     argv = captured[1]
     assert isinstance(argv, list)
-    assert argv[argv.index("--cwd") + 1] == os.path.sep
-    assert argv[argv.index("--root") + 1] == os.path.sep
+    assert argv[argv.index("--cwd") + 1] == "/deleted/workspace"
+    assert argv[argv.index("--root") + 1] == "/deleted/workspace"
+
+
+def test_deleted_cwd_without_pwd_falls_back_to_the_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PIN: the root is the last resort only, since a pack walk rooted there scans the machine."""
+
+    def gone() -> Never:
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(os, "getcwd", gone)
+    monkeypatch.delenv("PWD", raising=False)
+    assert client._cwd() == os.path.sep
 
 
 def test_run_execs_fixed_host_with_exact_product_identity(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Context

#30 (v12.23.3) taught `_cwd()` in `capt_hook_client/client.py` to return `os.path.sep` when `os.getcwd()` raised, so a hook fired from a workspace Orca had deleted under a live session would still be spelled. It is the third fix for that one condition: #29 stopped the worker crash that killed the shared worker and took the host socket down for every session on the machine, and #30 moved one layer up to the client shim.

The root is the wrong path to name. With neither `CLAUDE_PROJECT_DIR` nor `FACTORY_PROJECT_DIR` set, `--root` is spelled from the same value as `--cwd`, so it became `/`, and `packs/manager.detect_languages` then walked the entire filesystem. On macOS that walk reaches the synthetic `/.resolve`, which stats with `EINVAL` rather than a missing-file error, and `Path.is_file` propagates it. Observed on the released v12.23.3 build:

```
File ".../captain_hook/packs/manager.py", line 228, in gitignore_lines
    if not path.is_file():
OSError: [Errno 22] Invalid argument: '/.resolve/.gitignore'
```

On severity: a real Claude Code session always sets `CLAUDE_PROJECT_DIR`, so the `/` walk was reachable only without it. A probe that deliberately unset the variable found it; no user hit it.

## Summary

- `_cwd()` falls back to `PWD` before the filesystem root. The shell still carries the path after the directory is unlinked, so the dispatch stays truthful and inert: a root that does not exist walks to nothing, where `/` walks the whole machine. The root remains the last resort, for the case where `PWD` is unset too.
- `gitignore_lines` in `captain_hook/packs/manager.py` returns `[]` on `OSError`, not only on an absent file. This stands on its own: any walk root can contain a path that stats with something other than `ENOENT`, and one such path should not end a dispatch.

`--root`'s precedence is unchanged: an explicit `--root`, then `CLAUDE_PROJECT_DIR`, then `FACTORY_PROJECT_DIR`, then the cwd.

## Verification

- `tests/test_signed_host_client.py::test_deleted_cwd_still_spells_a_dispatch` now sets `PWD` and asserts the exec'd argv carries that path for both `--cwd` and `--root`.
- New `test_deleted_cwd_without_pwd_falls_back_to_the_root` clears `PWD` and pins the root as the last resort.
- New `tests/test_packs.py::test_gitignore_lines_survives_an_unstattable_path` raises `EINVAL` from `Path.is_file` and asserts an empty result.
- `uv run pytest tests/test_signed_host_client.py tests/test_packs.py` — 69 passed. CI runs the full suite on this push.

The unfixed behavior needs no synthetic reproduction: the traceback above is from the released v12.23.3 build running on the machine.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
