### PR TITLE
fix(dispatch): scale the budget to live sessions and gate the roster spawn, so a busy machine stops blocking hooks at zero CPU

### DIFF
--- a/captain_hook/packs/plugins.py
+++ b/captain_hook/packs/plugins.py
@@ -46,15 +46,8 @@ from captain_hook.util.fs import atomic_write, read_json
 from captain_hook.util.paths import resolve_cache_dir, resolve_claude_config_dir
 
 CLI_TIMEOUT_SECONDS = 60
-# A roster that cannot be read is retried on this timer rather than once per dispatch. The CLI spawns
-# Node, so a machine that has run out of fork capacity fails it — and re-running it per event is what
-# turns that shortage into a sustained spawn storm feeding itself.
 FAILURE_TTL = timedelta(seconds=15)
-# A root overtakes the machine-wide gate rather than queueing behind a holder this slow: the gate
-# exists to stagger a stampede, never to make one stuck session withhold the roster from every other.
 GATE_TIMEOUT_SECONDS = 10
-# How many spawns the gate admits at once. Wide enough that a handful of roots do not serialize,
-# narrow enough that a machine-wide invalidation cannot put every session's Node start in flight.
 GATE_WIDTH = 4
 GATE_POLL_SECONDS = 0.05
 # Bumped whenever a snapshot's meaning changes, so every older one is recomputed instead of served.

--- a/captain_hook/packs/plugins.py
+++ b/captain_hook/packs/plugins.py
@@ -29,12 +29,16 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from hashlib import sha256
 from pathlib import Path
 from shutil import which
 
-from filelock import FileLock
+from filelock import FileLock, Timeout
 from loguru import logger
 
 from captain_hook.packs import manager
@@ -42,6 +46,17 @@ from captain_hook.util.fs import atomic_write, read_json
 from captain_hook.util.paths import resolve_cache_dir, resolve_claude_config_dir
 
 CLI_TIMEOUT_SECONDS = 60
+# A roster that cannot be read is retried on this timer rather than once per dispatch. The CLI spawns
+# Node, so a machine that has run out of fork capacity fails it — and re-running it per event is what
+# turns that shortage into a sustained spawn storm feeding itself.
+FAILURE_TTL = timedelta(seconds=15)
+# A root overtakes the machine-wide gate rather than queueing behind a holder this slow: the gate
+# exists to stagger a stampede, never to make one stuck session withhold the roster from every other.
+GATE_TIMEOUT_SECONDS = 10
+# How many spawns the gate admits at once. Wide enough that a handful of roots do not serialize,
+# narrow enough that a machine-wide invalidation cannot put every session's Node start in flight.
+GATE_WIDTH = 4
+GATE_POLL_SECONDS = 0.05
 # Bumped whenever a snapshot's meaning changes, so every older one is recomputed instead of served.
 SNAPSHOT_VERSION = 2
 # Claude Code layers plugin scopes; when one id resolves at more than one scope the earlier entry here
@@ -63,6 +78,15 @@ def managed_settings_dirs(config: Path) -> tuple[Path, ...]:
 
 class PluginListError(Exception):
     """``claude plugin list --json`` exited nonzero or returned unusable output."""
+
+
+class RosterUnavailable(PluginListError):
+    """The CLI could not be run at all, rather than running and answering unusably.
+
+    The one failure that says nothing about the project: a machine out of fork capacity fails it for
+    every root at once. It is recorded machine-wide so the roots queued behind the gate are told
+    rather than each re-spawning, which is what turns a fork shortage into a sustained storm.
+    """
 
 
 def installed_plugins_path() -> Path:
@@ -112,6 +136,47 @@ def snapshot_cache_root() -> Path:
 
 def snapshot_path(root: Path) -> Path:
     return snapshot_cache_root() / f"{sha256(str(root.resolve()).encode()).hexdigest()[:16]}.plugins"
+
+
+def failure_path(root: Path) -> Path:
+    return snapshot_path(root).with_suffix(".failure")
+
+
+def gate_path(slot: int) -> Path:
+    return snapshot_cache_root() / f"roster.gate.{slot}"
+
+
+def outage_path() -> Path:
+    return snapshot_cache_root() / "roster.outage"
+
+
+@contextmanager
+def roster_gate() -> Iterator[None]:
+    """Admit at most :data:`GATE_WIDTH` roster CLI spawns machine-wide, degrading rather than failing.
+
+    A watched file is machine-wide, so one change invalidates every root's snapshot at once and every
+    session spawns Node together — the stampede that exhausts fork capacity. Holding a slot while
+    spawning bounds that instead. A slot is one ``flock``, which the kernel drops when its holder
+    dies, so a crashed session cannot wedge the machine; a machine still busy past
+    :data:`GATE_TIMEOUT_SECONDS` is overtaken rather than waited on.
+    """
+    deadline = time.monotonic() + GATE_TIMEOUT_SECONDS
+    while True:
+        for slot in range(GATE_WIDTH):
+            lock = FileLock(str(gate_path(slot)), timeout=0)
+            try:
+                lock.acquire()
+            except Timeout:
+                continue
+            try:
+                yield
+            finally:
+                lock.release()
+            return
+        if time.monotonic() >= deadline:
+            yield
+            return
+        time.sleep(GATE_POLL_SECONDS)
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,6 +244,85 @@ class PluginSnapshot:
 
     def fresh(self, records: tuple[StatRecord, ...]) -> bool:
         return self.stat == records
+
+
+@dataclass(frozen=True, slots=True)
+class RosterFailure:
+    """A recorded enumeration failure, so an unreadable roster costs one CLI spawn per TTL.
+
+    This is the negative half of the cache and never a roster: :func:`enabled_plugins` re-raises from
+    it rather than serving anything, so a failure stays a failure. "This project enables no
+    pack-shipping plugin" is a different fact and reaches disk only as a :class:`PluginSnapshot` — an
+    empty roster is never recorded here, and a failure is never recorded there.
+
+    Freshness is bounded twice. The stat tuple retires the record the moment a watched file moves, so
+    a fixed roster is picked up at once rather than after the timer; :data:`FAILURE_TTL` retires it
+    otherwise, so a transient failure — the fork exhaustion this exists for — recovers on its own.
+    """
+
+    stat: tuple[StatRecord, ...]
+    at: datetime
+    message: str
+
+    @classmethod
+    def load(cls, path: Path) -> RosterFailure | None:
+        if (data := read_json(path)) is None or data.get("version") != SNAPSHOT_VERSION:
+            return None
+        try:
+            return cls(
+                stat=tuple(tuple(rec) for rec in data["stat"]),
+                at=datetime.fromisoformat(data["at"]),
+                message=str(data["message"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def write(self, path: Path) -> None:
+        atomic_write(
+            path,
+            json.dumps(
+                {
+                    "version": SNAPSHOT_VERSION,
+                    "stat": [list(rec) for rec in self.stat],
+                    "at": self.at.isoformat(),
+                    "message": self.message,
+                }
+            ),
+        )
+
+    def fresh(self, records: tuple[StatRecord, ...], now: datetime) -> bool:
+        return self.stat == records and now - self.at < FAILURE_TTL
+
+
+@dataclass(frozen=True, slots=True)
+class RosterOutage:
+    """A machine-wide record that the CLI could not be spawned, bounded by :data:`FAILURE_TTL`.
+
+    Carries no roster and no stat tuple, because it records a condition of the machine rather than of
+    any project — so it never stands in for a root's answer. Enablement is resolved against the
+    project's settings stack and differs between roots, so it stays per root in
+    :class:`PluginSnapshot`; only the inability to ask at all is shared.
+    """
+
+    at: datetime
+    message: str
+
+    @classmethod
+    def load(cls, path: Path) -> RosterOutage | None:
+        if (data := read_json(path)) is None or data.get("version") != SNAPSHOT_VERSION:
+            return None
+        try:
+            return cls(at=datetime.fromisoformat(data["at"]), message=str(data["message"]))
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def write(self, path: Path) -> None:
+        atomic_write(
+            path, json.dumps({"version": SNAPSHOT_VERSION, "at": self.at.isoformat(), "message": self.message})
+        )
+
+    def fresh(self, now: datetime) -> bool:
+        return now - self.at < FAILURE_TTL
 
 
 def parse_plugin_entry(entry: object) -> EnabledPlugin | None:
@@ -277,9 +421,9 @@ def list_plugins_cli(root: Path, executable: str) -> tuple[EnabledPlugin, ...]:
             timeout=CLI_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired as e:
-        raise PluginListError(f"claude plugin list timed out after {CLI_TIMEOUT_SECONDS}s") from e
+        raise RosterUnavailable(f"claude plugin list timed out after {CLI_TIMEOUT_SECONDS}s") from e
     except OSError as e:
-        raise PluginListError(f"claude plugin list could not be executed: {e}") from e
+        raise RosterUnavailable(f"claude plugin list could not be executed: {e}") from e
     if result.returncode != 0:
         raise PluginListError(f"claude plugin list exited {result.returncode}: {result.stderr.strip()}")
     try:
@@ -306,16 +450,30 @@ def enabled_plugins(root: Path) -> tuple[EnabledPlugin, ...]:
     spawn.
 
     Raises :class:`PluginListError` when the roster cannot be read at all, ``claude`` missing from a
-    daemon's minimal ``PATH`` included, and caches nothing: an unreadable roster cached as an empty one
-    would make a broken pack layer indistinguishable from a project that enables no packs, which is how
-    every plugin-shipped pack on a machine went dead behind one warning line.
+    daemon's minimal ``PATH`` included, and never caches that as a roster: an unreadable roster cached
+    as an empty one would make a broken pack layer indistinguishable from a project that enables no
+    packs, which is how every plugin-shipped pack on a machine went dead behind one warning line. The
+    failure is instead recorded as a :class:`RosterFailure` and re-raised from for
+    :data:`FAILURE_TTL`, which keeps that distinction while bounding what a broken roster costs — the
+    CLI spawns Node, and re-running it per event is what lets a machine out of fork capacity fail the
+    spawn, cache nothing, and immediately spawn again.
+
+    The spawn itself runs under :func:`roster_gate`, which staggers the roots a machine-wide
+    invalidation would otherwise stampede, and a spawn that fails outright is recorded as a
+    :class:`RosterOutage` so the roots queued behind the gate are told rather than each re-spawning.
+    Only that inability is shared: enablement resolves against each project's settings stack, so a
+    root's roster is never served to another.
     """
     if not installed_plugins_path().is_file():
         return ()
     records = stat_records(root)
-    path = snapshot_path(root)
+    path, failure = snapshot_path(root), failure_path(root)
     if (snap := PluginSnapshot.load(path)) and snap.fresh(records):
         return snap.plugins
+    if (recorded := RosterFailure.load(failure)) and recorded.fresh(records, datetime.now(UTC)):
+        raise PluginListError(recorded.message)
+    if (outage := RosterOutage.load(outage_path())) and outage.fresh(datetime.now(UTC)):
+        raise RosterUnavailable(outage.message)
     if (executable := which("claude")) is None:
         raise PluginListError("claude is not on PATH, so the plugin roster cannot be enumerated")
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -323,9 +481,24 @@ def enabled_plugins(root: Path) -> tuple[EnabledPlugin, ...]:
         records = stat_records(root)
         if (snap := PluginSnapshot.load(path)) and snap.fresh(records):
             return snap.plugins
-        plugins = list_plugins_cli(root, executable)
-        PluginSnapshot(stat=records, plugins=plugins).write(path)
-        return plugins
+        if (recorded := RosterFailure.load(failure)) and recorded.fresh(records, datetime.now(UTC)):
+            raise PluginListError(recorded.message)
+        with roster_gate():
+            if (outage := RosterOutage.load(outage_path())) and outage.fresh(datetime.now(UTC)):
+                raise RosterUnavailable(outage.message)
+            try:
+                plugins = list_plugins_cli(root, executable)
+            except RosterUnavailable as exc:
+                RosterOutage(at=datetime.now(UTC), message=str(exc)).write(outage_path())
+                RosterFailure(stat=records, at=datetime.now(UTC), message=str(exc)).write(failure)
+                raise
+            except PluginListError as exc:
+                RosterFailure(stat=records, at=datetime.now(UTC), message=str(exc)).write(failure)
+                raise
+            PluginSnapshot(stat=records, plugins=plugins).write(path)
+            failure.unlink(missing_ok=True)
+            outage_path().unlink(missing_ok=True)
+            return plugins
 
 
 def plugin_pack_root(plugin: EnabledPlugin) -> Path:

--- a/internal/hookd/manager.go
+++ b/internal/hookd/manager.go
@@ -39,8 +39,7 @@ const (
 	// No wider budget can reach more interpreters than the worker cache holds.
 	maxParallelDispatch = maxLiveWorkers
 
-	// Nothing awaits a background dispatch, so it never competes for the
-	// blocking budget.
+	// Nothing awaits a background dispatch, so it never competes for the blocking budget.
 	asyncParallelDispatch = 4
 
 	parallelCeilingVar = "CAPT_HOOK_MAX_PARALLEL"

--- a/internal/hookd/manager.go
+++ b/internal/hookd/manager.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,17 @@ const (
 	workerIdleTTL = 30 * time.Minute
 
 	workerSweepInterval = 5 * time.Minute
+
+	minParallelDispatch = 16
+
+	// No wider budget can reach more interpreters than the worker cache holds.
+	maxParallelDispatch = maxLiveWorkers
+
+	// Nothing awaits a background dispatch, so it never competes for the
+	// blocking budget.
+	asyncParallelDispatch = 4
+
+	parallelCeilingVar = "CAPT_HOOK_MAX_PARALLEL"
 )
 
 // ErrWorkerCapacity refuses a dispatch that can neither start a worker nor
@@ -98,12 +110,32 @@ type workerManager struct {
 	wg      sync.WaitGroup
 }
 
-func newWorkerManager(owner daemonkit.Ctx, logWriter io.Writer) *workerManager {
-	return &workerManager{
-		owner: owner, logWriter: logWriter, scheduler: newScheduler(16),
-		entries: make(map[string]*workerEntry),
-		now:     time.Now, done: make(chan struct{}),
+func newWorkerManager(owner daemonkit.Ctx, logWriter io.Writer) (*workerManager, error) {
+	ceiling, err := parallelCeiling(os.Getenv(parallelCeilingVar))
+	if err != nil {
+		return nil, err
 	}
+	return &workerManager{
+		owner: owner, logWriter: logWriter,
+		// A ceiling set below the floor is meant, so the floor follows it down.
+		scheduler: newScheduler(min(minParallelDispatch, ceiling), ceiling, asyncParallelDispatch),
+		entries:   make(map[string]*workerEntry),
+		now:       time.Now, done: make(chan struct{}),
+	}, nil
+}
+
+func parallelCeiling(override string) (int, error) {
+	if strings.TrimSpace(override) == "" {
+		return maxParallelDispatch, nil
+	}
+	parsed, err := strconv.Atoi(strings.TrimSpace(override))
+	if err != nil {
+		return 0, fmt.Errorf("captain: %s must be a positive integer, got %q", parallelCeilingVar, override)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("captain: %s must be positive, got %d", parallelCeilingVar, parsed)
+	}
+	return parsed, nil
 }
 
 func (m *workerManager) dispatch(ctx context.Context, request EventRequest) (EventResponse, error) {
@@ -118,8 +150,8 @@ func (m *workerManager) dispatch(ctx context.Context, request EventRequest) (Eve
 	if session == "" {
 		session = fmt.Sprintf("pid:%d", request.ClientPID)
 	}
-	laneKey := key.id + "\x00" + session
-	return m.scheduler.run(ctx, laneKey, func() (EventResponse, error) {
+	laneKey := key.id + "\x00" + session + "\x00" + strconv.FormatBool(request.Async)
+	return m.scheduler.run(ctx, laneKey, request.Async, func() (EventResponse, error) {
 		entry, err := m.acquire(ctx, key)
 		if err != nil {
 			return EventResponse{}, err

--- a/internal/hookd/manager_test.go
+++ b/internal/hookd/manager_test.go
@@ -151,7 +151,7 @@ func fillIdleWorkers(manager *workerManager, base time.Time, cached error) {
 func TestWorkerManagerEvictsLeastRecentlyUsedAtTheBound(t *testing.T) {
 	t.Parallel()
 	cached := errors.New("served from the cache")
-	manager := newWorkerManager(daemonkit.Ctx{}, io.Discard)
+	manager := mustWorkerManager(t)
 	fillIdleWorkers(manager, time.Unix(0, 0), cached)
 
 	if _, err := manager.acquire(t.Context(), workerKey{id: "one-past-the-bound", root: "/fresh"}); errors.Is(err, ErrWorkerCapacity) {
@@ -170,7 +170,7 @@ func TestWorkerManagerEvictsLeastRecentlyUsedAtTheBound(t *testing.T) {
 // evicted: the dispatch holding it would lose its interpreter mid-call.
 func TestWorkerManagerRefusesWhenEveryWorkerIsBusy(t *testing.T) {
 	t.Parallel()
-	manager := newWorkerManager(daemonkit.Ctx{}, io.Discard)
+	manager := mustWorkerManager(t)
 	fillIdleWorkers(manager, time.Unix(0, 0), errors.New("served from the cache"))
 	for _, entry := range manager.entries {
 		entry.inflight = 1
@@ -191,7 +191,7 @@ func TestWorkerManagerSweepRetiresIdleAndDeadRoots(t *testing.T) {
 	now := time.Unix(1<<32, 0)
 	live := t.TempDir()
 	dead := filepath.Join(t.TempDir(), "reaped")
-	manager := newWorkerManager(daemonkit.Ctx{}, io.Discard)
+	manager := mustWorkerManager(t)
 	seed := func(id, root string, lastUsed time.Time, inflight int) {
 		entry := &workerEntry{
 			ready: make(chan struct{}), key: workerKey{id: id, root: root},
@@ -248,7 +248,7 @@ func TestEphemeralRootIsScoped(t *testing.T) {
 // occupying a slot until the sweep notices it.
 func TestReleaseRetiresEphemeralEntryImmediately(t *testing.T) {
 	t.Parallel()
-	manager := newWorkerManager(daemonkit.Ctx{}, io.Discard)
+	manager := mustWorkerManager(t)
 	entry := &workerEntry{
 		ready: make(chan struct{}), key: workerKey{id: "scratch", root: "/tmp/scratch"},
 		inflight: 1, ephemeral: true,
@@ -264,9 +264,18 @@ func TestReleaseRetiresEphemeralEntryImmediately(t *testing.T) {
 }
 
 func TestWorkerManagerCloseReportsJoinedProductGraph(t *testing.T) {
-	manager := newWorkerManager(daemonkit.Ctx{}, io.Discard)
+	manager := mustWorkerManager(t)
 	joined, err := manager.Close(context.Background())
 	if err != nil || !joined {
 		t.Fatalf("Close = joined %t, err %v", joined, err)
 	}
+}
+
+func mustWorkerManager(t *testing.T) *workerManager {
+	t.Helper()
+	manager, err := newWorkerManager(daemonkit.Ctx{}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manager
 }

--- a/internal/hookd/scheduler.go
+++ b/internal/hookd/scheduler.go
@@ -10,17 +10,11 @@ type lane struct {
 	refs int
 }
 
-// pool is one admission budget: dispatches executing against it, and the FIFO
-// queue waiting for a slot.
 type pool struct {
 	holders int
 	waiters []chan struct{}
 }
 
-// scheduler runs one dispatch per lane at a time, under two budgets. The
-// blocking one tracks the live sync lane count clamped to [floor, ceiling] —
-// below that count, unrelated sessions merely queue behind each other.
-// Background dispatches, which nothing awaits, get a fixed budget of their own.
 type scheduler struct {
 	mu        sync.Mutex
 	lanes     map[string]*lane
@@ -65,9 +59,7 @@ func (s *scheduler) acquireLane(key string, async bool) *lane {
 		l = &lane{gate: make(chan struct{}, 1)}
 		s.lanes[key] = l
 		if !async {
-			// A new sync lane widens the limit, so queued callers may now fit.
-			s.syncLanes++
-			s.promoteLocked(&s.sync, s.syncLimitLocked())
+			s.admitSyncLaneLocked()
 		}
 	}
 	l.refs++
@@ -84,6 +76,11 @@ func (s *scheduler) releaseLane(key string, async bool, l *lane) {
 			s.syncLanes--
 		}
 	}
+}
+
+func (s *scheduler) admitSyncLaneLocked() {
+	s.syncLanes++
+	s.promoteLocked(&s.sync, s.syncLimitLocked())
 }
 
 func (s *scheduler) syncLimitLocked() int {
@@ -122,10 +119,9 @@ func (s *scheduler) acquireSlot(ctx context.Context, async bool) error {
 	case <-ctx.Done():
 		s.mu.Lock()
 		p, _ := s.poolLocked(async)
-		dropped := dropWaiter(p, granted)
+		withdrawn := withdrawWaiter(p, granted)
 		s.mu.Unlock()
-		// A concurrent release already granted the slot; hand it back.
-		if !dropped {
+		if !withdrawn {
 			s.releaseSlot(async)
 		}
 		return ctx.Err()
@@ -140,8 +136,6 @@ func (s *scheduler) releaseSlot(async bool) {
 	s.promoteLocked(p, limit)
 }
 
-// promoteLocked admits queued callers in arrival order. holders may exceed the
-// limit when a closing lane narrowed it under callers already executing.
 func (s *scheduler) promoteLocked(p *pool, limit int) {
 	for len(p.waiters) > 0 && p.holders < limit {
 		granted := p.waiters[0]
@@ -151,7 +145,7 @@ func (s *scheduler) promoteLocked(p *pool, limit int) {
 	}
 }
 
-func dropWaiter(p *pool, granted chan struct{}) bool {
+func withdrawWaiter(p *pool, granted chan struct{}) bool {
 	for i, waiter := range p.waiters {
 		if waiter == granted {
 			p.waiters = append(p.waiters[:i], p.waiters[i+1:]...)

--- a/internal/hookd/scheduler.go
+++ b/internal/hookd/scheduler.go
@@ -10,52 +10,153 @@ type lane struct {
 	refs int
 }
 
+// pool is one admission budget: dispatches executing against it, and the FIFO
+// queue waiting for a slot.
+type pool struct {
+	holders int
+	waiters []chan struct{}
+}
+
+// scheduler runs one dispatch per lane at a time, under two budgets. The
+// blocking one tracks the live sync lane count clamped to [floor, ceiling] —
+// below that count, unrelated sessions merely queue behind each other.
+// Background dispatches, which nothing awaits, get a fixed budget of their own.
 type scheduler struct {
-	parallel chan struct{}
+	mu        sync.Mutex
+	lanes     map[string]*lane
+	syncLanes int
 
-	mu    sync.Mutex
-	lanes map[string]*lane
+	sync  pool
+	async pool
+
+	floor    int
+	ceiling  int
+	asyncCap int
 }
 
-func newScheduler(parallel int) *scheduler {
-	return &scheduler{parallel: make(chan struct{}, parallel), lanes: make(map[string]*lane)}
+func newScheduler(floor, ceiling, asyncCap int) *scheduler {
+	return &scheduler{
+		lanes: make(map[string]*lane),
+		floor: floor, ceiling: ceiling, asyncCap: asyncCap,
+	}
 }
 
-func (s *scheduler) run(ctx context.Context, key string, execute func() (EventResponse, error)) (EventResponse, error) {
-	l := s.acquireLane(key)
-	defer s.releaseLane(key, l)
+func (s *scheduler) run(ctx context.Context, key string, async bool, execute func() (EventResponse, error)) (EventResponse, error) {
+	l := s.acquireLane(key, async)
+	defer s.releaseLane(key, async, l)
 	select {
 	case l.gate <- struct{}{}:
 		defer func() { <-l.gate }()
 	case <-ctx.Done():
 		return EventResponse{}, ctx.Err()
 	}
-	select {
-	case s.parallel <- struct{}{}:
-		defer func() { <-s.parallel }()
-	case <-ctx.Done():
-		return EventResponse{}, ctx.Err()
+	if err := s.acquireSlot(ctx, async); err != nil {
+		return EventResponse{}, err
 	}
+	defer s.releaseSlot(async)
 	return execute()
 }
 
-func (s *scheduler) acquireLane(key string) *lane {
+func (s *scheduler) acquireLane(key string, async bool) *lane {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	l := s.lanes[key]
 	if l == nil {
 		l = &lane{gate: make(chan struct{}, 1)}
 		s.lanes[key] = l
+		if !async {
+			// A new sync lane widens the limit, so queued callers may now fit.
+			s.syncLanes++
+			s.promoteLocked(&s.sync, s.syncLimitLocked())
+		}
 	}
 	l.refs++
 	return l
 }
 
-func (s *scheduler) releaseLane(key string, l *lane) {
+func (s *scheduler) releaseLane(key string, async bool, l *lane) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	l.refs--
 	if l.refs == 0 {
 		delete(s.lanes, key)
+		if !async {
+			s.syncLanes--
+		}
 	}
+}
+
+func (s *scheduler) syncLimitLocked() int {
+	switch {
+	case s.syncLanes < s.floor:
+		return s.floor
+	case s.syncLanes > s.ceiling:
+		return s.ceiling
+	default:
+		return s.syncLanes
+	}
+}
+
+func (s *scheduler) poolLocked(async bool) (*pool, int) {
+	if async {
+		return &s.async, s.asyncCap
+	}
+	return &s.sync, s.syncLimitLocked()
+}
+
+func (s *scheduler) acquireSlot(ctx context.Context, async bool) error {
+	s.mu.Lock()
+	p, limit := s.poolLocked(async)
+	if p.holders < limit {
+		p.holders++
+		s.mu.Unlock()
+		return nil
+	}
+	granted := make(chan struct{})
+	p.waiters = append(p.waiters, granted)
+	s.mu.Unlock()
+
+	select {
+	case <-granted:
+		return nil
+	case <-ctx.Done():
+		s.mu.Lock()
+		p, _ := s.poolLocked(async)
+		dropped := dropWaiter(p, granted)
+		s.mu.Unlock()
+		// A concurrent release already granted the slot; hand it back.
+		if !dropped {
+			s.releaseSlot(async)
+		}
+		return ctx.Err()
+	}
+}
+
+func (s *scheduler) releaseSlot(async bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, limit := s.poolLocked(async)
+	p.holders--
+	s.promoteLocked(p, limit)
+}
+
+// promoteLocked admits queued callers in arrival order. holders may exceed the
+// limit when a closing lane narrowed it under callers already executing.
+func (s *scheduler) promoteLocked(p *pool, limit int) {
+	for len(p.waiters) > 0 && p.holders < limit {
+		granted := p.waiters[0]
+		p.waiters = p.waiters[1:]
+		p.holders++
+		close(granted)
+	}
+}
+
+func dropWaiter(p *pool, granted chan struct{}) bool {
+	for i, waiter := range p.waiters {
+		if waiter == granted {
+			p.waiters = append(p.waiters[:i], p.waiters[i+1:]...)
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hookd/scheduler_test.go
+++ b/internal/hookd/scheduler_test.go
@@ -2,14 +2,73 @@ package hookd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
+// blockingRun holds every admitted dispatch inside execute until release closes,
+// recording how many ran at once so a test can assert the admitted width.
+type blockingRun struct {
+	scheduler *scheduler
+	active    atomic.Int32
+	maximum   atomic.Int32
+	entered   atomic.Int32
+	release   chan struct{}
+	done      chan struct{}
+}
+
+func newBlockingRun(s *scheduler) *blockingRun {
+	return &blockingRun{scheduler: s, release: make(chan struct{}), done: make(chan struct{}, 64)}
+}
+
+func (b *blockingRun) start(key string, async bool) {
+	go func() {
+		_, _ = b.scheduler.run(context.Background(), key, async, func() (EventResponse, error) {
+			b.entered.Add(1)
+			current := b.active.Add(1)
+			for {
+				peak := b.maximum.Load()
+				if current <= peak || b.maximum.CompareAndSwap(peak, current) {
+					break
+				}
+			}
+			<-b.release
+			b.active.Add(-1)
+			return EventResponse{}, nil
+		})
+		b.done <- struct{}{}
+	}()
+}
+
+func (b *blockingRun) awaitEntered(t *testing.T, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for b.entered.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("entered dispatches = %d, want %d", b.entered.Load(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func (b *blockingRun) finish(t *testing.T, count int) {
+	t.Helper()
+	close(b.release)
+	for range count {
+		select {
+		case <-b.done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("dispatch did not finish")
+		}
+	}
+}
+
 func TestSchedulerSerializesOneSessionWithoutBlockingAnother(t *testing.T) {
 	t.Parallel()
-	scheduler := newScheduler(2)
+	scheduler := newScheduler(2, 2, 2)
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	secondSameEntered := make(chan struct{})
@@ -17,7 +76,7 @@ func TestSchedulerSerializesOneSessionWithoutBlockingAnother(t *testing.T) {
 	results := make(chan error, 3)
 
 	go func() {
-		_, err := scheduler.run(context.Background(), "session-a", func() (EventResponse, error) {
+		_, err := scheduler.run(context.Background(), "session-a", false, func() (EventResponse, error) {
 			close(firstEntered)
 			<-releaseFirst
 			return EventResponse{}, nil
@@ -26,14 +85,14 @@ func TestSchedulerSerializesOneSessionWithoutBlockingAnother(t *testing.T) {
 	}()
 	<-firstEntered
 	go func() {
-		_, err := scheduler.run(context.Background(), "session-a", func() (EventResponse, error) {
+		_, err := scheduler.run(context.Background(), "session-a", false, func() (EventResponse, error) {
 			close(secondSameEntered)
 			return EventResponse{}, nil
 		})
 		results <- err
 	}()
 	go func() {
-		_, err := scheduler.run(context.Background(), "session-b", func() (EventResponse, error) {
+		_, err := scheduler.run(context.Background(), "session-b", false, func() (EventResponse, error) {
 			close(differentEntered)
 			return EventResponse{}, nil
 		})
@@ -65,30 +124,203 @@ func TestSchedulerSerializesOneSessionWithoutBlockingAnother(t *testing.T) {
 
 func TestSchedulerHonorsGlobalParallelism(t *testing.T) {
 	t.Parallel()
-	scheduler := newScheduler(2)
-	var active atomic.Int32
-	var maximum atomic.Int32
-	release := make(chan struct{})
-	done := make(chan struct{}, 8)
+	run := newBlockingRun(newScheduler(2, 2, 2))
 	for i := range 8 {
-		go func() {
-			_, _ = scheduler.run(context.Background(), string(rune('a'+i)), func() (EventResponse, error) {
-				current := active.Add(1)
-				for current > maximum.Load() && !maximum.CompareAndSwap(maximum.Load(), current) {
-				}
-				<-release
-				active.Add(-1)
-				return EventResponse{}, nil
-			})
-			done <- struct{}{}
-		}()
+		run.start(fmt.Sprintf("session-%d", i), false)
 	}
+	run.awaitEntered(t, 2)
 	time.Sleep(25 * time.Millisecond)
-	if got := maximum.Load(); got != 2 {
+	if got := run.maximum.Load(); got != 2 {
 		t.Fatalf("maximum parallel executions = %d, want 2", got)
 	}
+	run.finish(t, 8)
+}
+
+// The regression this fix exists for: a fixed budget narrower than the number of
+// live sessions forced unrelated sessions to queue behind each other, because a
+// lane gate already limits each of them to one executing dispatch.
+func TestSchedulerWidensWithSessionDemand(t *testing.T) {
+	t.Parallel()
+	run := newBlockingRun(newScheduler(1, 16, 2))
+	for i := range 6 {
+		run.start(fmt.Sprintf("session-%d", i), false)
+	}
+	run.awaitEntered(t, 6)
+	if got := run.maximum.Load(); got != 6 {
+		t.Fatalf("maximum parallel executions = %d, want 6", got)
+	}
+	run.finish(t, 6)
+}
+
+func TestSchedulerClampsDemandToCeiling(t *testing.T) {
+	t.Parallel()
+	run := newBlockingRun(newScheduler(1, 3, 2))
+	for i := range 9 {
+		run.start(fmt.Sprintf("session-%d", i), false)
+	}
+	run.awaitEntered(t, 3)
+	time.Sleep(25 * time.Millisecond)
+	if got := run.maximum.Load(); got != 3 {
+		t.Fatalf("maximum parallel executions = %d, want 3", got)
+	}
+	run.finish(t, 9)
+}
+
+func TestSchedulerHoldsDemandAtFloor(t *testing.T) {
+	t.Parallel()
+	run := newBlockingRun(newScheduler(4, 16, 2))
+	for i := range 3 {
+		run.start(fmt.Sprintf("session-%d", i), false)
+	}
+	run.awaitEntered(t, 3)
+	if got := run.maximum.Load(); got != 3 {
+		t.Fatalf("maximum parallel executions = %d, want 3", got)
+	}
+	run.finish(t, 3)
+}
+
+func TestSchedulerReleasesSlotWhenQueuedCallerCancels(t *testing.T) {
+	t.Parallel()
+	scheduler := newScheduler(1, 1, 2)
+	run := newBlockingRun(scheduler)
+	run.start("session-a", false)
+	run.awaitEntered(t, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	queued := make(chan error, 1)
+	go func() {
+		_, err := scheduler.run(ctx, "session-b", false, func() (EventResponse, error) {
+			return EventResponse{}, nil
+		})
+		queued <- err
+	}()
+	time.Sleep(25 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-queued:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("queued dispatch error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled dispatch did not return")
+	}
+	run.finish(t, 1)
+
+	admitted := make(chan struct{})
+	go func() {
+		_, _ = scheduler.run(context.Background(), "session-c", false, func() (EventResponse, error) {
+			close(admitted)
+			return EventResponse{}, nil
+		})
+	}()
+	select {
+	case <-admitted:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled dispatch leaked its slot")
+	}
+}
+
+func TestSchedulerCapsBackgroundLaneSeparately(t *testing.T) {
+	t.Parallel()
+	run := newBlockingRun(newScheduler(1, 16, 2))
+	for i := range 6 {
+		run.start(fmt.Sprintf("session-%d", i), true)
+	}
+	run.awaitEntered(t, 2)
+	time.Sleep(25 * time.Millisecond)
+	if got := run.maximum.Load(); got != 2 {
+		t.Fatalf("maximum background executions = %d, want 2", got)
+	}
+	run.finish(t, 6)
+}
+
+// Claude Code awaits the blocking dispatch and nothing awaits the background one.
+func TestSchedulerBackgroundSaturationLeavesBlockingLaneFree(t *testing.T) {
+	t.Parallel()
+	scheduler := newScheduler(1, 16, 2)
+	background := newBlockingRun(scheduler)
+	for i := range 5 {
+		background.start(fmt.Sprintf("background-%d", i), true)
+	}
+	background.awaitEntered(t, 2)
+
+	blocking := make(chan struct{})
+	go func() {
+		_, _ = scheduler.run(context.Background(), "session-a", false, func() (EventResponse, error) {
+			close(blocking)
+			return EventResponse{}, nil
+		})
+	}()
+	select {
+	case <-blocking:
+	case <-time.After(time.Second):
+		t.Fatal("blocking dispatch queued behind the background lane")
+	}
+	background.finish(t, 5)
+}
+
+func TestSchedulerSeparatesOneSessionsBlockingAndBackgroundLanes(t *testing.T) {
+	t.Parallel()
+	scheduler := newScheduler(1, 16, 2)
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		_, _ = scheduler.run(context.Background(), "session-a\x00true", true, func() (EventResponse, error) {
+			close(held)
+			<-release
+			return EventResponse{}, nil
+		})
+	}()
+	<-held
+
+	ran := make(chan struct{})
+	go func() {
+		_, _ = scheduler.run(context.Background(), "session-a\x00false", false, func() (EventResponse, error) {
+			close(ran)
+			return EventResponse{}, nil
+		})
+	}()
+	select {
+	case <-ran:
+	case <-time.After(time.Second):
+		t.Fatal("a session's blocking dispatch serialized behind its own background dispatch")
+	}
 	close(release)
-	for range 8 {
-		<-done
+}
+
+func TestParallelCeilingReadsOverride(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name     string
+		override string
+		want     int
+	}{
+		{name: "unset", override: "", want: maxParallelDispatch},
+		{name: "blank", override: "   ", want: maxParallelDispatch},
+		{name: "explicit", override: "24", want: 24},
+		{name: "padded", override: "  24  ", want: 24},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parallelCeiling(testCase.override)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != testCase.want {
+				t.Fatalf("parallelCeiling(%q) = %d, want %d", testCase.override, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestParallelCeilingRefusesAnUnusableOverride(t *testing.T) {
+	t.Parallel()
+	for _, override := range []string{"wide", "0", "-3", "3.5"} {
+		t.Run(override, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parallelCeiling(override); err == nil {
+				t.Fatalf("parallelCeiling(%q) accepted an unusable override", override)
+			}
+		})
 	}
 }

--- a/internal/hookd/scheduler_test.go
+++ b/internal/hookd/scheduler_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-// blockingRun holds every admitted dispatch inside execute until release closes,
-// recording how many ran at once so a test can assert the admitted width.
 type blockingRun struct {
 	scheduler *scheduler
 	active    atomic.Int32
@@ -136,9 +134,6 @@ func TestSchedulerHonorsGlobalParallelism(t *testing.T) {
 	run.finish(t, 8)
 }
 
-// The regression this fix exists for: a fixed budget narrower than the number of
-// live sessions forced unrelated sessions to queue behind each other, because a
-// lane gate already limits each of them to one executing dispatch.
 func TestSchedulerWidensWithSessionDemand(t *testing.T) {
 	t.Parallel()
 	run := newBlockingRun(newScheduler(1, 16, 2))
@@ -234,7 +229,6 @@ func TestSchedulerCapsBackgroundLaneSeparately(t *testing.T) {
 	run.finish(t, 6)
 }
 
-// Claude Code awaits the blocking dispatch and nothing awaits the background one.
 func TestSchedulerBackgroundSaturationLeavesBlockingLaneFree(t *testing.T) {
 	t.Parallel()
 	scheduler := newScheduler(1, 16, 2)

--- a/internal/hookd/server.go
+++ b/internal/hookd/server.go
@@ -39,7 +39,10 @@ func (s *Server) Run(ctx context.Context) error {
 		return fmt.Errorf("captain: open host log: %w", err)
 	}
 	_, err = daemonkit.Serve(ctx, s.daemon, func(hostCtx daemonkit.Ctx) (daemonkit.Product, error) {
-		manager := newWorkerManager(hostCtx, logFile)
+		manager, err := newWorkerManager(hostCtx, logFile)
+		if err != nil {
+			return nil, err
+		}
 		manager.startSweeper(workerSweepInterval)
 		return &hostProduct{
 			manager: manager,

--- a/internal/hookd/server_test.go
+++ b/internal/hookd/server_test.go
@@ -3,7 +3,6 @@ package hookd
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -52,7 +51,7 @@ func TestHostDaemonValidatesOnBothHalves(t *testing.T) {
 func TestHostProductHandleDispatchesEveryOpAndRefusesTheRest(t *testing.T) {
 	t.Parallel()
 	product := &hostProduct{
-		manager: newWorkerManager(daemonkit.Ctx{}, io.Discard),
+		manager: mustWorkerManager(t),
 		hub:     newNotificationHub(),
 	}
 	ctx := context.Background()

--- a/tests/test_plugin_packs.py
+++ b/tests/test_plugin_packs.py
@@ -423,15 +423,13 @@ def test_cli_failure_raises_and_is_never_cached_as_a_roster(
     with pytest.raises(plugins.PluginListError):
         plugins.enabled_plugins(root)
     assert not plugins.snapshot_path(root).exists()  # a failure is never cached as an authoritative roster
-    assert plugins.failure_path(root).exists()  # it is recorded as a failure instead
+    assert plugins.failure_path(root).exists()
     with pytest.raises(plugins.PluginListError):
         plugins.enabled_plugins(root)
     assert calls.read_text() == "x"  # the recorded failure is re-raised rather than re-spawning the CLI
 
 
 def test_empty_roster_is_cached_as_success_not_as_a_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The distinction the negative cache must never blur: "this project enables no pack-shipping
-    # plugin" is an authoritative empty roster, not an enumeration that failed.
     plant_installed()
     (root := tmp_path / "proj").mkdir()
     calls = tmp_path / "calls"
@@ -737,11 +735,7 @@ def test_pack_list_renders_builtin_and_plugin_ids(tmp_path: Path, monkeypatch: p
     assert "plugin:show@mkt" in result.stdout  # the enabled plugin's pack renders with its full plugin id
 
 
-# --- machine-wide roster gate ---------------------------------------------------------
-
-
 def test_gate_bounds_concurrent_roots_under_one_invalidation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The stampede this gate exists for: one machine-wide file change invalidates every root at once.
     plant_installed()
     roots = [tmp_path / f"proj{i}" for i in range(10)]
     for root in roots:
@@ -778,13 +772,12 @@ def test_gate_bounds_concurrent_roots_under_one_invalidation(tmp_path: Path, mon
         thread.join(timeout=30)
 
     assert errors == []
-    assert overlap <= plugins.GATE_WIDTH  # the gate held
-    assert overlap < len(roots)  # and it bounded them: never all ten at once
+    assert overlap <= plugins.GATE_WIDTH
+    assert overlap < len(roots)
 
 
 def test_gate_never_shares_one_root_enablement_with_another(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The correctness line the gate must not cross: `enabled` resolves against each project's
-    # settings stack, so a roster is never served to a root that did not ask for it.
+    # `enabled` resolves against each project's settings stack, so it differs between roots.
     plant_installed()
     (enabled_root := tmp_path / "on").mkdir()
     (disabled_root := tmp_path / "off").mkdir()
@@ -801,12 +794,11 @@ def test_gate_never_shares_one_root_enablement_with_another(tmp_path: Path, monk
 
     assert len(plugins.enabled_plugins(enabled_root)) == 1
     assert plugins.enabled_plugins(disabled_root) == ()
-    assert len(plugins.enabled_plugins(enabled_root)) == 1  # served from its own snapshot, not the sibling's
+    assert len(plugins.enabled_plugins(enabled_root)) == 1
 
 
 def test_gate_held_by_a_dead_holder_does_not_wedge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # flock is released by the kernel when its holder dies, so a crashed session cannot withhold the
-    # roster from the machine. Proven with a real killed process, not a released lock object.
+    # flock is released by the kernel when its holder dies, so a killed process frees its slot.
     plant_installed()
     (root := tmp_path / "proj").mkdir()
     plugins.gate_path(0).parent.mkdir(parents=True, exist_ok=True)
@@ -835,7 +827,7 @@ def test_gate_held_by_a_dead_holder_does_not_wedge(tmp_path: Path, monkeypatch: 
         if holder.poll() is None:
             holder.kill()
 
-    assert len(plugins.enabled_plugins(root)) == 1  # the dead holder's lock was reclaimed
+    assert len(plugins.enabled_plugins(root)) == 1
 
 
 def test_spawn_outage_is_recorded_machine_wide_and_spares_queued_roots(
@@ -862,14 +854,13 @@ def test_spawn_outage_is_recorded_machine_wide_and_spares_queued_roots(
     with pytest.raises(plugins.RosterUnavailable):
         plugins.enabled_plugins(first)
     with pytest.raises(plugins.RosterUnavailable):
-        plugins.enabled_plugins(second)  # a different root, never spawned for
+        plugins.enabled_plugins(second)
     assert spawns == 1
     assert plugins.outage_path().exists()
 
 
 def test_roster_shape_failure_stays_local_to_its_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Only an unspawnable CLI is a machine condition. A roster the CLI answered unusably says
-    # something about that root alone, so it must never suppress a sibling.
+    # Only an unspawnable CLI is a machine condition; an unusable answer is about that root alone.
     plant_installed()
     (broken := tmp_path / "broken").mkdir()
     (healthy := tmp_path / "healthy").mkdir()
@@ -900,7 +891,7 @@ def test_recovered_spawn_clears_the_machine_wide_outage(tmp_path: Path, monkeypa
         at=datetime.now(UTC) - plugins.FAILURE_TTL - timedelta(seconds=1), message="stale outage"
     ).write(plugins.outage_path())
 
-    assert len(plugins.enabled_plugins(root)) == 1  # the expired outage did not suppress the spawn
+    assert len(plugins.enabled_plugins(root)) == 1
     assert not plugins.outage_path().exists()
 
 
@@ -919,7 +910,7 @@ def test_gate_admits_exactly_its_width_at_once(tmp_path: Path, monkeypatch: pyte
     for thread in holders:
         thread.start()
     for _ in range(plugins.GATE_WIDTH):
-        assert inside.acquire(timeout=10)  # every slot is usable concurrently
+        assert inside.acquire(timeout=10)
 
     entered = threading.Event()
 
@@ -929,9 +920,9 @@ def test_gate_admits_exactly_its_width_at_once(tmp_path: Path, monkeypatch: pyte
 
     extra = threading.Thread(target=overflow, daemon=True)
     extra.start()
-    assert not entered.wait(timeout=1)  # the width+1 caller waits for a slot
+    assert not entered.wait(timeout=1)
 
     release.set()
-    assert entered.wait(timeout=10)  # and is admitted once one frees
+    assert entered.wait(timeout=10)
     for thread in [*holders, extra]:
         thread.join(timeout=10)

--- a/tests/test_plugin_packs.py
+++ b/tests/test_plugin_packs.py
@@ -4,7 +4,11 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 import sys
+import threading
+import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -408,7 +412,7 @@ def test_ctime_only_watched_rewrite_refreshes_roster(tmp_path: Path, monkeypatch
         pytest.param({"raw_stdout": "not json", "returncode": 0}, id="bad_json"),
     ],
 )
-def test_cli_failure_raises_and_caches_nothing(
+def test_cli_failure_raises_and_is_never_cached_as_a_roster(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: dict[str, object]
 ) -> None:
     plant_installed()
@@ -419,9 +423,79 @@ def test_cli_failure_raises_and_caches_nothing(
     with pytest.raises(plugins.PluginListError):
         plugins.enabled_plugins(root)
     assert not plugins.snapshot_path(root).exists()  # a failure is never cached as an authoritative roster
+    assert plugins.failure_path(root).exists()  # it is recorded as a failure instead
     with pytest.raises(plugins.PluginListError):
         plugins.enabled_plugins(root)
-    assert calls.read_text() == "xx"  # the next event re-asks instead of serving the failure back
+    assert calls.read_text() == "x"  # the recorded failure is re-raised rather than re-spawning the CLI
+
+
+def test_empty_roster_is_cached_as_success_not_as_a_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The distinction the negative cache must never blur: "this project enables no pack-shipping
+    # plugin" is an authoritative empty roster, not an enumeration that failed.
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[])
+
+    assert plugins.enabled_plugins(root) == ()
+    assert plugins.snapshot_path(root).exists()
+    assert not plugins.failure_path(root).exists()
+    assert plugins.enabled_plugins(root) == ()
+    assert calls.read_text() == "x"
+
+
+def test_recorded_failure_expires_with_its_ttl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[], returncode=1)
+
+    with pytest.raises(plugins.PluginListError):
+        plugins.enabled_plugins(root)
+    recorded = plugins.RosterFailure.load(plugins.failure_path(root))
+    assert recorded is not None
+    aged = plugins.RosterFailure(
+        stat=recorded.stat, at=recorded.at - plugins.FAILURE_TTL - timedelta(seconds=1), message=recorded.message
+    )
+    aged.write(plugins.failure_path(root))
+
+    with pytest.raises(plugins.PluginListError):
+        plugins.enabled_plugins(root)
+    assert calls.read_text() == "xx"  # the expired record re-asks
+
+
+def test_recorded_failure_is_retried_when_a_watched_file_moves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[], returncode=1)
+
+    with pytest.raises(plugins.PluginListError):
+        plugins.enabled_plugins(root)
+    (settings := root / ".claude" / "settings.json").parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text("{}")
+
+    with pytest.raises(plugins.PluginListError):
+        plugins.enabled_plugins(root)
+    assert calls.read_text() == "xx"  # a settings change retries at once rather than after the TTL
+
+
+def test_recovered_roster_clears_the_recorded_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    plugin = write_plugin_pack(tmp_path, "show", "1.0.0")
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[], returncode=1)
+
+    with pytest.raises(plugins.PluginListError):
+        plugins.enabled_plugins(root)
+    assert plugins.failure_path(root).exists()
+
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls2", roster=[roster_entry("mkt/show", plugin)])
+    (settings := root / ".claude" / "settings.json").parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text("{}")
+
+    assert len(plugins.enabled_plugins(root)) == 1
+    assert not plugins.failure_path(root).exists()
 
 
 def test_dead_shebang_claude_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -661,3 +735,203 @@ def test_pack_list_renders_builtin_and_plugin_ids(tmp_path: Path, monkeypatch: p
     assert result.returncode == 0, result.stdout + result.stderr
     assert "builtin:general" in result.stdout  # an active wheel builtin renders with its namespaced id
     assert "plugin:show@mkt" in result.stdout  # the enabled plugin's pack renders with its full plugin id
+
+
+# --- machine-wide roster gate ---------------------------------------------------------
+
+
+def test_gate_bounds_concurrent_roots_under_one_invalidation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The stampede this gate exists for: one machine-wide file change invalidates every root at once.
+    plant_installed()
+    roots = [tmp_path / f"proj{i}" for i in range(10)]
+    for root in roots:
+        root.mkdir()
+    plugin = write_plugin_pack(tmp_path, "show")
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[roster_entry("mkt/show", plugin)])
+
+    overlap = 0
+    live = 0
+    real = plugins.list_plugins_cli
+
+    def watched(root: Path, executable: str) -> tuple[plugins.EnabledPlugin, ...]:
+        nonlocal overlap, live
+        live += 1
+        overlap = max(overlap, live)
+        try:
+            return real(root, executable)
+        finally:
+            live -= 1
+
+    monkeypatch.setattr(plugins, "list_plugins_cli", watched)
+    errors: list[BaseException] = []
+
+    def enumerate_root(root: Path) -> None:
+        try:
+            plugins.enabled_plugins(root)
+        except BaseException as exc:  # noqa: BLE001 - surfaced by the assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=enumerate_root, args=(root,)) for root in roots]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert errors == []
+    assert overlap <= plugins.GATE_WIDTH  # the gate held
+    assert overlap < len(roots)  # and it bounded them: never all ten at once
+
+
+def test_gate_never_shares_one_root_enablement_with_another(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The correctness line the gate must not cross: `enabled` resolves against each project's
+    # settings stack, so a roster is never served to a root that did not ask for it.
+    plant_installed()
+    (enabled_root := tmp_path / "on").mkdir()
+    (disabled_root := tmp_path / "off").mkdir()
+    plugin = write_plugin_pack(tmp_path, "show")
+
+    def per_root(root: Path, executable: str) -> tuple[plugins.EnabledPlugin, ...]:
+        del executable
+        return (plugins.EnabledPlugin(id="mkt/show", version="1.0.0", root=str(plugin), scope="user"),) * (
+            root.resolve() == enabled_root.resolve()
+        )
+
+    monkeypatch.setattr(plugins, "list_plugins_cli", per_root)
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[roster_entry("mkt/show", plugin)])
+
+    assert len(plugins.enabled_plugins(enabled_root)) == 1
+    assert plugins.enabled_plugins(disabled_root) == ()
+    assert len(plugins.enabled_plugins(enabled_root)) == 1  # served from its own snapshot, not the sibling's
+
+
+def test_gate_held_by_a_dead_holder_does_not_wedge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # flock is released by the kernel when its holder dies, so a crashed session cannot withhold the
+    # roster from the machine. Proven with a real killed process, not a released lock object.
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    plugins.gate_path(0).parent.mkdir(parents=True, exist_ok=True)
+    plugin = write_plugin_pack(tmp_path, "show")
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[roster_entry("mkt/show", plugin)])
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import fcntl,sys,time\n"
+            "handles = [open(p, 'w') for p in sys.argv[1:]]\n"
+            "for h in handles: fcntl.flock(h, fcntl.LOCK_EX)\n"
+            "time.sleep(300)",
+            *[str(plugins.gate_path(slot)) for slot in range(plugins.GATE_WIDTH)],
+        ],
+        stdin=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not all(plugins.gate_path(s).exists() for s in range(plugins.GATE_WIDTH)):
+            time.sleep(0.05)
+        holder.kill()
+        holder.wait(timeout=10)
+    finally:
+        if holder.poll() is None:
+            holder.kill()
+
+    assert len(plugins.enabled_plugins(root)) == 1  # the dead holder's lock was reclaimed
+
+
+def test_spawn_outage_is_recorded_machine_wide_and_spares_queued_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plant_installed()
+    (first := tmp_path / "one").mkdir()
+    (second := tmp_path / "two").mkdir()
+    plugin = write_plugin_pack(tmp_path, "show")
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[roster_entry("mkt/show", plugin)])
+
+    spawns = 0
+
+    def exhausted(root: Path, executable: str) -> tuple[plugins.EnabledPlugin, ...]:
+        del root, executable
+        nonlocal spawns
+        spawns += 1
+        raise plugins.RosterUnavailable(
+            "claude plugin list could not be executed: [Errno 35] Resource temporarily unavailable"
+        )
+
+    monkeypatch.setattr(plugins, "list_plugins_cli", exhausted)
+
+    with pytest.raises(plugins.RosterUnavailable):
+        plugins.enabled_plugins(first)
+    with pytest.raises(plugins.RosterUnavailable):
+        plugins.enabled_plugins(second)  # a different root, never spawned for
+    assert spawns == 1
+    assert plugins.outage_path().exists()
+
+
+def test_roster_shape_failure_stays_local_to_its_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only an unspawnable CLI is a machine condition. A roster the CLI answered unusably says
+    # something about that root alone, so it must never suppress a sibling.
+    plant_installed()
+    (broken := tmp_path / "broken").mkdir()
+    (healthy := tmp_path / "healthy").mkdir()
+    plugin = write_plugin_pack(tmp_path, "show")
+    real = plugins.list_plugins_cli
+
+    def selective(root: Path, executable: str) -> tuple[plugins.EnabledPlugin, ...]:
+        if root.resolve() == broken.resolve():
+            raise plugins.PluginListError("claude plugin list returned unparseable JSON")
+        return real(root, executable)
+
+    monkeypatch.setattr(plugins, "list_plugins_cli", selective)
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[roster_entry("mkt/show", plugin)])
+
+    with pytest.raises(plugins.PluginListError):
+        plugins.enabled_plugins(broken)
+    assert not plugins.outage_path().exists()
+    assert len(plugins.enabled_plugins(healthy)) == 1
+
+
+def test_recovered_spawn_clears_the_machine_wide_outage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    plugin = write_plugin_pack(tmp_path, "show")
+    install_claude(tmp_path, monkeypatch, calls=tmp_path / "calls", roster=[roster_entry("mkt/show", plugin)])
+    plugins.outage_path().parent.mkdir(parents=True, exist_ok=True)
+    plugins.RosterOutage(
+        at=datetime.now(UTC) - plugins.FAILURE_TTL - timedelta(seconds=1), message="stale outage"
+    ).write(plugins.outage_path())
+
+    assert len(plugins.enabled_plugins(root)) == 1  # the expired outage did not suppress the spawn
+    assert not plugins.outage_path().exists()
+
+
+def test_gate_admits_exactly_its_width_at_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    del tmp_path, monkeypatch
+    plugins.gate_path(0).parent.mkdir(parents=True, exist_ok=True)
+    inside = threading.Semaphore(0)
+    release = threading.Event()
+
+    def hold() -> None:
+        with plugins.roster_gate():
+            inside.release()
+            release.wait(timeout=30)
+
+    holders = [threading.Thread(target=hold, daemon=True) for _ in range(plugins.GATE_WIDTH)]
+    for thread in holders:
+        thread.start()
+    for _ in range(plugins.GATE_WIDTH):
+        assert inside.acquire(timeout=10)  # every slot is usable concurrently
+
+    entered = threading.Event()
+
+    def overflow() -> None:
+        with plugins.roster_gate():
+            entered.set()
+
+    extra = threading.Thread(target=overflow, daemon=True)
+    extra.start()
+    assert not entered.wait(timeout=1)  # the width+1 caller waits for a slot
+
+    release.set()
+    assert entered.wait(timeout=10)  # and is admitted once one frees
+    for thread in [*holders, extra]:
+        thread.join(timeout=10)


### PR DESCRIPTION
## Context

A machine ground to a halt under many concurrent Claude Code sessions: load around 10, 1428 processes, every MCP server in a session failing to connect, and `claude plugin list` failing with `[Errno 35] Resource temporarily unavailable`. The machine was out of fork capacity. A warm capt-hook hook invocation measured 3.6–6.2s wall for 0.06s of CPU, against the dispatch path's own ~3ms target; nearly all of it was blocking, not compute.

Three things compounded.

`internal/hookd/scheduler.go` admitted dispatches through a fixed `chan struct{}` of 16, `newScheduler(16)` in `manager.go`. A lane gate already caps one session at one executing dispatch, so any global limit below the live session count guarantees unrelated sessions queue behind each other for nothing. That was the multi-second wait at zero CPU.

`captain_hook/packs/plugins.py` cached nothing on a roster failure. Out of fork capacity, the `claude plugin list` spawn failed with EAGAIN, nothing was written, and the next dispatch respawned it at once: a positive-feedback loop, with 813 `PluginListError` and 167 `BlockingIOError: [Errno 35]` in the daemon log. The snapshot is also invalidated by machine-wide files, so one write to `installed_plugins.json` invalidated all 6566 cached root snapshots at once and every session spawned the CLI together.

Background dispatches shared the same 16 slots and the same per-session lane as blocking ones, so a session's blocking hook could serialize behind its own background work.

## Summary

**Demand-scaled dispatch budget.** The semaphore is now a pool with an explicit FIFO waiter queue whose limit is re-evaluated on every admission, so the width can change while callers are queued. The limit tracks the live sync lane count clamped to [16, `maxLiveWorkers`]: 16 is the old hardcoded value, so a quiet machine behaves as before; 64 is the worker cache cap, past which no width reaches another interpreter. `CAPT_HOOK_MAX_PARALLEL` overrides the ceiling, and a bad value is now fatal: `parallelCeiling` returns `(int, error)` for anything unparseable or non-positive, `newWorkerManager` returns it, and `server.go` surfaces it, so a typo fails startup loudly instead of silently halving throughput. Unset or blank is still the default.

**Separate background pool.** `asyncParallelDispatch = 4`, and `strconv.FormatBool(request.Async)` joins the lane key, so background work has its own budget and its own lane. `Async` was already on the wire; no protocol change.

**Single-flight roster spawn, with a negative cache.** Four pieces in `plugins.py`:

- `RosterFailure` records a failed enumeration next to the root's snapshot, and `enabled_plugins` re-raises from it for `FAILURE_TTL` (15s). It is bounded twice: by the watched-file stat tuple, so a fixed roster is picked up at once rather than after the timer, and by the TTL. An empty roster is still cached as a `PluginSnapshot`, never as a failure; the two are different types in different files, and the snapshot write is reachable only on the CLI's successful return.
- `roster_gate()` wraps the spawn in a machine-wide semaphore of `GATE_WIDTH` (4) slots, each a `FileLock` on `roster.gate.<slot>`, nested inside the existing per-root lock so ordering is always (root, machine). A caller takes any free slot, polling every `GATE_POLL_SECONDS` (50ms) until one opens; past `GATE_TIMEOUT_SECONDS` (10) it overtakes the gate and spawns ungated rather than raising. filelock resolves to `UnixFileLock`, an `flock` the kernel drops when the holder dies, so a crashed session cannot wedge a slot.
- `RosterUnavailable(PluginListError)` is raised only where the CLI could not run at all (`TimeoutExpired`, `OSError`, the EAGAIN case). It writes a machine-wide `RosterOutage` that queued waiters check on release, so a fork-exhausted machine costs one spawn per TTL instead of one per root. Every other `PluginListError` (nonzero exit, bad JSON, corrupt shape) stays per-root: a roster the CLI answered unusably says something about that root alone.
- Enablement is never collapsed across roots. `RosterOutage` carries no roster and no stat tuple; only the inability to ask is shared. A single machine-wide roster snapshot was tried first and rejected on evidence: across CLI runs the entry set is identical (131 entries, same keys) but the `enabled` flag varies by cwd, and drifted 120 → 124 between two back-to-back runs from the same root with `installed_plugins.json` unchanged, because concurrent sessions rewrite their own `settings.local.json`. `enabled` is not a machine-wide fact; a shared snapshot would have loaded packs into repos that disabled them and dropped them from repos that enabled them.

Two behaviors widen. The gate admits at most four concurrent spawns, so under a machine-wide invalidation N roots are bounded rather than stampeding: the last of them waits roughly N/4 spawns instead of N, capped at 10s before it overtakes the gate. Bounding fork pressure is the point; 4 was chosen over strict serialization to trade some staggering for latency. And a machine-wide outage suppresses plugin packs for every root for up to 15s; that condition genuinely is machine-wide, and `cli.py` already degrades to `[]` with the fault recorded rather than failing the session. This is the one change whose blast radius grew beyond a single root.

## Deployment

The Go changes are daemon-side scheduling only and the wire protocol is untouched, so live 12.22.3 and 12.22.5 clients keep dispatching correctly against a rebuilt host. It lands only once the host app is rebuilt and reinstalled, and host/client build fencing means the two move together.

## Verification

`uv run pytest`: 4127 passed, 6 skipped in 382.40s. `go test ./... -race -count=1` ok; `go vet`, `gofmt -l`, and `ruff check` clean.

Nine Go tests cover the scheduler: widening with session demand, clamping to the ceiling, holding at the floor, returning a slot when a queued caller cancels, the background pool's separate cap, background saturation leaving the blocking lane free, one session's blocking and background lanes staying separate, and `parallelCeiling` reading and refusing an override. Twelve Python tests cover the roster path, and two of them were mutation-tested so the coverage is not vacuous: `test_gate_bounds_concurrent_roots_under_one_invalidation` runs ten threads over ten roots and asserts the peak of concurrent spawns is at most `GATE_WIDTH` and strictly less than the number of roots; with the gate neutered all ten spawn at once and both assertions fail. `test_spawn_outage_is_recorded_machine_wide_and_spares_queued_roots` fails `assert 2 == 1` when the outage write is removed. CI runs the full suite on this push.

https://claude.ai/code/session_01UyGU5fdNbhFe2sC7V1KZin
