### PR TITLE
fix(hookd): spawn the worker from the temp dir when the root is gone, so a session whose workspace was reaped still gets a worker

### DIFF
--- a/internal/hookd/manager.go
+++ b/internal/hookd/manager.go
@@ -343,11 +343,23 @@ func (m *workerManager) start(ctx context.Context, key workerKey) (*workerClient
 // hook response can carry it.
 func workerCmd(key workerKey) daemonkit.Cmd {
 	return daemonkit.Cmd{
-		Path: key.python, Args: []string{"-P", "-m", "captain_hook.worker"}, Dir: key.root,
+		Path: key.python, Args: []string{"-P", "-m", "captain_hook.worker"}, Dir: workerDir(key.root),
 		Env:     mergeEnvironment(workerBaseEnvironment(os.Environ()), key.env),
 		Session: true,
 		Exec:    daemonkit.ServingSameUser(),
 	}
+}
+
+// workerDir is the root, or the temp directory once that root is gone. A session
+// outlives the workspace it was started in — a deleted worktree, a reaped Orca
+// workspace — and spawning into a missing Dir fails the chdir, which posix_spawn
+// reports as a missing interpreter, so the dispatch dies before a worker exists.
+// An empty directory detects the same languages a deleted one would.
+func workerDir(root string) string {
+	if info, err := os.Stat(root); err == nil && info.IsDir() {
+		return root
+	}
+	return os.TempDir()
 }
 
 // settle terminates one retired worker on a budget of its own: the request

--- a/internal/hookd/manager_test.go
+++ b/internal/hookd/manager_test.go
@@ -92,14 +92,15 @@ func TestWorkerBaseEnvironmentSeedsDiscoveryWithoutLeakingFirstClientScope(t *te
 // running under a retired generation.
 func TestWorkerCmdOwnsTheWholeWorkerSession(t *testing.T) {
 	t.Parallel()
+	root := t.TempDir()
 	cmd := workerCmd(workerKey{
-		id: "abc", root: "/tmp/repo", python: "/usr/bin/python3", build: "12.9.1",
+		id: "abc", root: root, python: "/usr/bin/python3", build: "12.9.1",
 		env: map[string]string{"HOOKS_PROFILE": "strict"},
 	})
 	if !cmd.Session {
 		t.Fatal("worker spawn does not own its descendants")
 	}
-	if cmd.Path != "/usr/bin/python3" || cmd.Dir != "/tmp/repo" ||
+	if cmd.Path != "/usr/bin/python3" || cmd.Dir != root ||
 		len(cmd.Args) != 3 || cmd.Args[0] != "-P" || cmd.Args[1] != "-m" || cmd.Args[2] != "captain_hook.worker" {
 		t.Fatalf("worker spawn = %q %q in %q", cmd.Path, cmd.Args, cmd.Dir)
 	}
@@ -112,6 +113,19 @@ func TestWorkerCmdOwnsTheWholeWorkerSession(t *testing.T) {
 	if seen["LANG"] != "C" || seen["PATH"] == "" || seen["HOOKS_PROFILE"] != "strict" {
 		t.Fatalf("worker environment: LANG=%q PATH set=%t HOOKS_PROFILE=%q",
 			seen["LANG"], seen["PATH"] != "", seen["HOOKS_PROFILE"])
+	}
+}
+
+// TestWorkerCmdSurvivesARootDeletedUnderTheSession pins the fallback: a chdir
+// into a missing Dir surfaces as posix_spawn reporting the interpreter absent,
+// which killed every dispatch from a session whose workspace had been reaped
+// before it first needed a worker (observed 2026-09-02).
+func TestWorkerCmdSurvivesARootDeletedUnderTheSession(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "reaped")
+	cmd := workerCmd(workerKey{id: "abc", root: root, python: "/usr/bin/python3", build: "12.9.1"})
+	if cmd.Dir != os.TempDir() {
+		t.Fatalf("worker spawn Dir = %q, want the temp dir for a missing root", cmd.Dir)
 	}
 }
 


### PR DESCRIPTION
## Context

Fourth and last fix for one condition: Orca reaps `~/.orca/workspaces` directories under sessions that are still alive and still firing hooks. #29 (v12.23.2) fixed the worker's `worker_log_key` crash; that was the outage, since it killed the shared worker and took the host's socket down for every session on the machine. #30 and #31 fixed the client shim's `--cwd` and `--root` spelling. This one is host-side, and it is the failure that remained after all three.

`workerCmd` in `internal/hookd/manager.go` spawned the Python worker with `Dir: key.root`. When that root no longer exists the chdir fails, and Go's spawn reports the failure as `ENOENT` naming the executable, so the operator sees a missing interpreter rather than a missing directory:

```
captain: spawn Python product worker: posix_spawn /Users/yasyf/.daemonkit/tools/capt-hook/12.23.4/capt-hook/bin/python: no such file or directory
```

The path in that message exists and runs. Proven on the machine two ways: executing that same interpreter from a deleted cwd succeeds, and a dispatch with an existing `--root` and a deleted `--cwd` succeeds while one with a deleted `--root` fails. `Dir` is the determinant, not the binary.

Why it stayed hidden through the earlier fixes: workers are pooled per root, so a worker spawned while the root still existed kept serving dispatches after the deletion. That is why the outage presented as a worker crash deep in `worker_log_key` rather than as a spawn failure. Only a session whose root is already gone when it first needs a worker reaches this path, and that session gets no dispatch at all.

## Summary

`workerDir` returns the root when it is an existing directory and `os.TempDir()` otherwise, and `workerCmd` spawns into it. An empty directory detects the same languages a deleted one would, so nothing is lost, and `-P` still keeps the Dir off `sys.path`.

This closes the second follow-up #29 listed (a worker spawned for a `--root` that no longer exists), by making that spawn succeed rather than fail fast.

## Verification

- New `TestWorkerCmdSurvivesARootDeletedUnderTheSession` asserts the fallback. Confirmed in both directions: with `Dir: key.root` restored it fails with the real root path in the failure message, and it passes with the fix.
- `TestWorkerCmdOwnsTheWholeWorkerSession` pinned `Dir == "/tmp/repo"`, a path that does not exist, so it moved to a `t.TempDir()` root; that assertion is only meaningful against a directory that is really there.
- `go test ./internal/hookd/ -count=1` passes; `gofmt -l` and `go vet` are clean. CI runs the full suite on this push.

## Follow-up

`capt-hookd serve` still treats a live pid in `daemon.records` as proof the daemon is serving, with no check that the socket exists. That is the state that made the original outage unrecoverable without a manual kill, and it is untouched here.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
