### PR TITLE
perf(hook): read the version from Info.plist instead of exec'ing capt-hookd, so every hook stops paying two execve for a string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,4 +132,4 @@ jobs:
         env:
           GOSUMDB: "off"
           GOPROXY: direct
-        run: go run github.com/yasyf/binrun/cmd/binrun@v0.1.1 -- parse captain_hook/bin/hook.binrun
+        run: go run github.com/yasyf/binrun/cmd/binrun@v0.4.0 -- parse captain_hook/bin/hook.binrun

--- a/captain_hook/bin/capt-hook.binrun
+++ b/captain_hook/bin/capt-hook.binrun
@@ -4,8 +4,8 @@
   "name": "capt-hook",
   "kind": "python-tool",
   "version": {
-    "command": ["/bin/bash", "-c", "exec \"$HOME/Applications/Captain Hook.app/Contents/Helpers/capt-hookd\" version"],
-    "json_field": "build"
+    "file": "~/Applications/Captain Hook.app/Contents/Info.plist",
+    "plist_key": "CFBundleShortVersionString"
   },
   "tool": {
     "dist": "capt-hook",

--- a/captain_hook/bin/hook.binrun
+++ b/captain_hook/bin/hook.binrun
@@ -4,8 +4,8 @@
   "name": "capt-hook",
   "kind": "python-tool",
   "version": {
-    "command": ["/bin/bash", "-c", "exec \"$HOME/Applications/Captain Hook.app/Contents/Helpers/capt-hookd\" version"],
-    "json_field": "build"
+    "file": "~/Applications/Captain Hook.app/Contents/Info.plist",
+    "plist_key": "CFBundleShortVersionString"
   },
   "tool": {
     "dist": "capt-hook",

--- a/tests/test_formula_deployment_contract.py
+++ b/tests/test_formula_deployment_contract.py
@@ -72,12 +72,16 @@ def test_signed_controller_stops_only_the_exact_installed_generation() -> None:
         assert forbidden not in source
 
 
-def test_binrun_version_probes_use_the_stable_signed_host() -> None:
-    expected = (
-        '["/bin/bash", "-c", "exec \\"$HOME/Applications/Captain Hook.app'
-        '/Contents/Helpers/capt-hookd\\" version"]'
-    )
+def test_binrun_version_reads_the_stable_signed_host_without_spawning_it() -> None:
+    """PIN: the version comes off the fixed signed bundle, and costs no execve to read.
+
+    Spawning the host cost two execve per hook — a bash and a multi-MB signed Mach-O —
+    to read a string the bundle already publishes, which on a machine whose endpoint
+    security inspects every exec dominated the whole dispatch.
+    """
     for name in ("capt-hook.binrun", "hook.binrun"):
         descriptor = (ROOT / "captain_hook/bin" / name).read_text()
-        assert expected in descriptor
+        assert '"file": "~/Applications/Captain Hook.app/Contents/Info.plist"' in descriptor
+        assert '"plist_key": "CFBundleShortVersionString"' in descriptor
+        assert '"command"' not in descriptor
         assert "capt-hook-host" not in descriptor


### PR DESCRIPTION
## Context

Every hook invocation on this machine started by resolving which capt-hook build to run. `captain_hook/bin/hook.binrun` did that with `version.command`: `/bin/bash -c 'exec "$HOME/Applications/Captain Hook.app/Contents/Helpers/capt-hookd" version'`, two `execve` of a multi-MB signed Mach-O, to read a string that already sits in the app bundle's `Info.plist`.

Measured on the machine that prompted this work, with the installed binrun v0.4.0 against both descriptors, three runs each:

| descriptor | wall |
|---|---|
| `version.command` (before) | 0.75 / 0.70 / 0.55 s |
| `version.file` + `plist_key` (after) | 0.05 / 0.01 / 0.02 s |

Both resolve to the identical artifact, `~/.daemonkit/tools/capt-hook/12.24.1/capt-hook/bin/hook`. That is roughly 0.6s off every hook invocation on a loaded machine; the same comparison on an idle one measured 0.52s. The number understates the effect because each `execve` on this host costs 0.3–0.6s under EndpointSecurity inspection (SentinelOne plus Kandji), which is why hook dispatches here were measured anywhere from 3s to 54s.

## Summary

Two lines in `captain_hook/bin/hook.binrun`: the `version` source is now `file: ~/Applications/Captain Hook.app/Contents/Info.plist` with `plist_key: CFBundleShortVersionString`.

`.github/workflows/ci.yml` moves its descriptor-validation pin from `binrun@v0.1.1` to `binrun@v0.4.0`. This is required, not incidental: v0.1.1 predates the `version.file` source and rejects the new descriptor with `invalid descriptor: version has neither static nor command`. That is the generic message, because the descriptor schema version deliberately stays 1, so the friendly "upgrade binrun" hint never fires.

## Why this can land now

This is the last change in a four-repo chain, and the ordering was the whole risk:

1. daemonkit v0.24.0 added the `version.file` source.
2. binrun v0.4.0 repinned to it.
3. cc-skills bumped the fleet shim pin to binrun v0.4.0 and gave the shim a stamp file, so a host that already has a runner re-bootstraps instead of keeping its old one forever. Before that, Arm 2 exec'd any installed runner with no version check; this machine was still on v0.1.1 from July.
4. captain-hook re-rendered that shim: `RUNNER_TAG="v0.4.0"` plus the stamp check now sit in `captain_hook/scripts/install-binary.sh` on main.

The shim runs before the descriptor is parsed, so one release can carry both. A host on an older runner takes the stamp mismatch, bootstraps v0.4.0, and only then hands it this descriptor.

The residual gap: Arm 1 execs a `binrun` found on `PATH` (a brew install or a dev build) with no stamp check, so a host with an old binrun on `PATH` hits the generic invalid-descriptor error on every hook until that binary is updated.

## Verification

- `go run github.com/yasyf/binrun/cmd/binrun@v0.4.0 -- parse captain_hook/bin/hook.binrun` succeeds locally. The same command at v0.1.1 fails with the message quoted above, which is what the CI pin change is for.
- The resolution comparison in Context, run with the installed runner against both descriptors.

CI runs the descriptor parse on this push.

https://claude.ai/code/session_014gKfZvjihGgFrEVCr3NJJb
