### PR TITLE
perf(plugins): digest settings to the enablement keys and refresh a stale roster behind the read, so settings churn stops costing every root a 3.3s spawn

### DIFF
--- a/captain_hook/daemon/registry.py
+++ b/captain_hook/daemon/registry.py
@@ -78,10 +78,10 @@ def _language_markers(root: Path) -> tuple[str, ...]:
     return tuple(sorted(manager.detect_languages(root)))
 
 
-def _claude_stats(root: Path) -> tuple[plugins.StatRecord, ...]:
-    # The stat tuple whose change means a plugin was installed, enabled, or disabled — discovery then
+def _claude_stats(root: Path) -> tuple[plugins.FingerprintRecord, ...]:
+    # The fingerprint whose change means a plugin was installed, enabled, or disabled — discovery then
     # re-runs the CLI and rewrites the roster snapshot the next fingerprint reads.
-    return plugins.stat_records(root)
+    return plugins.fingerprint(root)
 
 
 def _plugin_trees(root: Path) -> tuple[PluginTree, ...]:

--- a/captain_hook/packs/plugins.py
+++ b/captain_hook/packs/plugins.py
@@ -5,11 +5,13 @@ under the plugin root; the dispatcher loads every enabled plugin whose root ship
 plugins come from ``claude plugin list --json`` — the sanctioned interface, which resolves
 ``enabled`` against the project's settings stack — but that CLI spawns Node (~1s), far too slow
 for the ~3ms dispatch hot path. So the roster is cached per project in a ``<key>.plugins``
-snapshot, invalidated by the stat tuple of the files that shape it: Claude Code's
-``installed_plugins.json`` (mtime only — undocumented, never parsed), the user settings, and the
-project's two settings files. A watched-file change (a plugin install, an enable or disable) re-runs
-the CLI once; every other event reads the snapshot. The fixed-path probe itself runs live per
-discovery (cheap stats), so a pack edit inside a plugin dir needs no snapshot invalidation.
+snapshot, invalidated by a fingerprint over the files that shape it: Claude Code's
+``installed_plugins.json`` by stat (undocumented, never parsed) and every settings file by a digest
+of the keys that decide enablement, so a session rewriting its settings for unrelated reasons no
+longer costs every root a spawn. An invalidation re-runs the CLI once; every other event reads the
+snapshot, and a snapshot that has merely gone stale is served while the re-run happens behind it.
+The fixed-path probe itself runs live per discovery (cheap stats), so a pack edit inside a plugin
+dir needs no snapshot invalidation.
 
 Pack load is all-or-nothing: a plugin advertising ``capt-hook/`` with a missing descriptor or hooks
 dir raises rather than silently dropping guards. The CLI's roster is machine-wide — a ``project`` or
@@ -29,6 +31,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -51,7 +54,12 @@ GATE_TIMEOUT_SECONDS = 10
 GATE_WIDTH = 4
 GATE_POLL_SECONDS = 0.05
 # Bumped whenever a snapshot's meaning changes, so every older one is recomputed instead of served.
-SNAPSHOT_VERSION = 2
+SNAPSHOT_VERSION = 3
+# The settings keys a roster answer turns on. Marketplaces cannot move it alone, but are digested
+# anyway: a key wrongly left out serves a stale roster as a fresh one.
+PLUGIN_SETTINGS_KEYS = ("enabledPlugins", "extraKnownMarketplaces")
+REFRESHING: set[str] = set()
+REFRESHING_GUARD = threading.Lock()
 # Claude Code layers plugin scopes; when one id resolves at more than one scope the earlier entry here
 # outranks the later, mirroring settings precedence. An unknown scope ranks lowest.
 SCOPE_PRECEDENCE = ("local", "project", "user")
@@ -63,6 +71,8 @@ MANAGED_SETTINGS_DIRS = (
 )
 
 type StatRecord = tuple[str, int, int, int] | tuple[str, None]
+type SettingsRecord = tuple[str, str]
+type FingerprintRecord = StatRecord | SettingsRecord
 
 
 def managed_settings_dirs(config: Path) -> tuple[Path, ...]:
@@ -108,19 +118,44 @@ def stat_record(path: Path) -> StatRecord:
     return (abs_path, st.st_mtime_ns, st.st_ctime_ns, st.st_size)
 
 
-def dropin_records(dropin_dir: Path) -> tuple[StatRecord, ...]:
-    """A ``managed-settings.d`` dir's own stat plus one per contained ``*.json`` (sorted); a lone
-    ``(path, None)`` when the dir is absent. The dir stat catches drop-in adds/removes, the per-file
-    records catch edits."""
+def settings_record(path: Path) -> FingerprintRecord:
+    """A settings file digested down to the keys that decide a roster, or its stat when it has none.
+
+    An unparseable or non-object file falls back to :func:`stat_record`, so a corrupt settings file
+    keeps the coarse behaviour rather than reading as "declares no plugins" — the digest may only ever
+    make invalidation rarer for files it actually understands.
+    """
+    if not isinstance(data := read_json(path), dict):
+        return stat_record(path)
+    payload = json.dumps({k: data[k] for k in PLUGIN_SETTINGS_KEYS if k in data}, sort_keys=True)
+    return (os.path.abspath(path), sha256(payload.encode()).hexdigest()[:16])
+
+
+def fingerprint_record(path: Path) -> FingerprintRecord:
+    """One watched path's contribution to the fingerprint.
+
+    ``installed_plugins.json`` stays a stat rather than a digest: Claude Code's format for it is
+    undocumented and this module has never parsed it, so a digest could silently miss a field that
+    moves the roster. It changes only when a plugin is installed, updated, or removed — rare enough
+    that invalidating every root on it costs little, unlike the settings files a session rewrites for
+    reasons that have nothing to do with plugins.
+    """
+    return stat_record(path) if path == installed_plugins_path() else settings_record(path)
+
+
+def dropin_records(dropin_dir: Path) -> tuple[FingerprintRecord, ...]:
+    """A ``managed-settings.d`` dir's own stat plus one digest per contained ``*.json`` (sorted); a
+    lone ``(path, None)`` when the dir is absent. The dir stat catches drop-in adds/removes, the
+    per-file records catch edits."""
     if not dropin_dir.is_dir():
         return (stat_record(dropin_dir),)
-    return (stat_record(dropin_dir), *(stat_record(p) for p in sorted(dropin_dir.glob("*.json"))))
+    return (stat_record(dropin_dir), *(settings_record(p) for p in sorted(dropin_dir.glob("*.json"))))
 
 
-def stat_records(root: Path) -> tuple[StatRecord, ...]:
+def fingerprint(root: Path) -> tuple[FingerprintRecord, ...]:
     config = resolve_claude_config_dir()
     dropins = tuple(rec for d in managed_settings_dirs(config) for rec in dropin_records(d / "managed-settings.d"))
-    return tuple(stat_record(p) for p in watched_paths(root)) + dropins
+    return tuple(fingerprint_record(p) for p in watched_paths(root)) + dropins
 
 
 def snapshot_cache_root() -> Path:
@@ -183,7 +218,7 @@ class EnabledPlugin:
 
 @dataclass(frozen=True, slots=True)
 class PluginSnapshot:
-    stat: tuple[StatRecord, ...]
+    stat: tuple[FingerprintRecord, ...]
     plugins: tuple[EnabledPlugin, ...]
 
     @classmethod
@@ -235,7 +270,7 @@ class PluginSnapshot:
             ),
         )
 
-    def fresh(self, records: tuple[StatRecord, ...]) -> bool:
+    def fresh(self, records: tuple[FingerprintRecord, ...]) -> bool:
         return self.stat == records
 
 
@@ -253,7 +288,7 @@ class RosterFailure:
     otherwise, so a transient failure — the fork exhaustion this exists for — recovers on its own.
     """
 
-    stat: tuple[StatRecord, ...]
+    stat: tuple[FingerprintRecord, ...]
     at: datetime
     message: str
 
@@ -283,7 +318,7 @@ class RosterFailure:
             ),
         )
 
-    def fresh(self, records: tuple[StatRecord, ...], now: datetime) -> bool:
+    def fresh(self, records: tuple[FingerprintRecord, ...], now: datetime) -> bool:
         return self.stat == records and now - self.at < FAILURE_TTL
 
 
@@ -433,6 +468,33 @@ def list_plugins_cli(root: Path, executable: str) -> tuple[EnabledPlugin, ...]:
     return dedupe_scoped_roster(parsed, root)
 
 
+def refresh_behind(root: Path) -> None:
+    """Re-resolve ``root``'s roster on a background thread, at most one in flight per root.
+
+    The stale snapshot has already been served by the time this runs, so the CLI's Node start — 3.3s
+    on a loaded machine — stops sitting on the dispatch a session is waiting for. A refresh that
+    fails records through the same :class:`RosterFailure` and :class:`RosterOutage` path as any other
+    spawn, which is also what stops it retrying: the next attempt reads that record and returns
+    without spawning until it expires.
+    """
+    key = str(root.resolve())
+    with REFRESHING_GUARD:
+        if key in REFRESHING:
+            return
+        REFRESHING.add(key)
+    threading.Thread(target=run_refresh, args=(root, key), daemon=True).start()
+
+
+def run_refresh(root: Path, key: str) -> None:
+    try:
+        resolve_roster(root, fingerprint(root))
+    except PluginListError:
+        logger.opt(exception=True).debug("background roster refresh failed")
+    finally:
+        with REFRESHING_GUARD:
+            REFRESHING.discard(key)
+
+
 def enabled_plugins(root: Path) -> tuple[EnabledPlugin, ...]:
     """The plugins Claude Code has enabled for ``root``, cached per project with stat invalidation.
 
@@ -459,10 +521,23 @@ def enabled_plugins(root: Path) -> tuple[EnabledPlugin, ...]:
     """
     if not installed_plugins_path().is_file():
         return ()
-    records = stat_records(root)
-    path, failure = snapshot_path(root), failure_path(root)
-    if (snap := PluginSnapshot.load(path)) and snap.fresh(records):
+    records = fingerprint(root)
+    if snap := PluginSnapshot.load(snapshot_path(root)):
+        if not snap.fresh(records):
+            refresh_behind(root)
         return snap.plugins
+    return resolve_roster(root, records)
+
+
+def resolve_roster(root: Path, records: tuple[FingerprintRecord, ...]) -> tuple[EnabledPlugin, ...]:
+    """Re-run the CLI for ``root`` and rewrite its snapshot, blocking until it answers.
+
+    The one path that spawns. :func:`enabled_plugins` reaches it only for a root with no snapshot at
+    all, where there is nothing to serve and guessing an empty roster would be the very collapse
+    :class:`RosterFailure` exists to prevent; every refresh of an existing snapshot comes through
+    :func:`refresh_behind` instead.
+    """
+    path, failure = snapshot_path(root), failure_path(root)
     if (recorded := RosterFailure.load(failure)) and recorded.fresh(records, datetime.now(UTC)):
         raise PluginListError(recorded.message)
     if (outage := RosterOutage.load(outage_path())) and outage.fresh(datetime.now(UTC)):
@@ -471,7 +546,7 @@ def enabled_plugins(root: Path) -> tuple[EnabledPlugin, ...]:
         raise PluginListError("claude is not on PATH, so the plugin roster cannot be enumerated")
     path.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(str(path.with_name(path.name + ".lock"))):
-        records = stat_records(root)
+        records = fingerprint(root)
         if (snap := PluginSnapshot.load(path)) and snap.fresh(records):
             return snap.plugins
         if (recorded := RosterFailure.load(failure)) and recorded.fresh(records, datetime.now(UTC)):

--- a/captain_hook/util/userpath.py
+++ b/captain_hook/util/userpath.py
@@ -31,7 +31,9 @@ from captain_hook.util.paths import resolve_cache_dir
 # Only a worker with no cached answer to fall back to spends this much.
 PROBE_TIMEOUT_SECONDS = 5
 
-REFRESH_TIMEOUT_SECONDS = 1
+# A bound under the shell's real cost never completes: it times out, falls back, and leaves the
+# record stale for the next worker to retry. A login fish measures 1.43-1.50s.
+REFRESH_TIMEOUT_SECONDS = 3
 
 CACHE_TTL = timedelta(hours=12)
 

--- a/tests/test_daemon_registry.py
+++ b/tests/test_daemon_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import threading
 import time
@@ -27,7 +28,7 @@ def write_snapshot(root: Path, roster: list[tuple[str, str]]) -> Path:
     path = plugins.snapshot_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
     plugins.PluginSnapshot(
-        stat=plugins.stat_records(root),
+        stat=plugins.fingerprint(root),
         plugins=tuple(plugins.EnabledPlugin(id=pid, version="1.0.0", root=proot) for pid, proot in roster),
     ).write(path)
     return path
@@ -177,16 +178,20 @@ def test_plugin_tree_skips_a_plugin_whose_hooks_dir_vanishes(
 
 @pytest.mark.parametrize("idx", range(len(plugins.watched_paths(Path("/x")))))
 def test_watched_file_mtime_bump_changes_fingerprint(project: CliState, idx: int) -> None:
-    # An mtime bump on any watched roster input misses the cache; the absolute managed-settings system
-    # paths (/Library, /etc) aren't sandbox-writable, so skip those slots.
+    # A change to any watched roster input misses the cache — an mtime bump on the installed-plugin
+    # roster, an enablement edit on a settings file. The absolute managed-settings system paths
+    # (/Library, /etc) aren't sandbox-writable, so skip those slots.
     path = plugins.watched_paths(project.root)[idx]
     if not (path.is_relative_to(project.root) or path.is_relative_to(resolve_claude_config_dir())):
         pytest.skip(f"{path} is an absolute managed-settings system path — not sandbox-writable")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{}\n")
     before = fp(project)
-    st = path.stat()
-    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    if path == plugins.installed_plugins_path():
+        st = path.stat()
+        os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    else:
+        path.write_text(json.dumps({"enabledPlugins": {"marker@mkt": True}}))
     assert fp(project) != before
 
 

--- a/tests/test_pack_tools.py
+++ b/tests/test_pack_tools.py
@@ -117,7 +117,7 @@ def plant_installed() -> None:
 def write_snapshot(root: Path, roster: Sequence[tuple[str, Path]]) -> None:
     (path := plugins.snapshot_path(root)).parent.mkdir(parents=True, exist_ok=True)
     plugins.PluginSnapshot(
-        stat=plugins.stat_records(root),
+        stat=plugins.fingerprint(root),
         plugins=tuple(plugins.EnabledPlugin(id=pid, version="1.0.0", root=str(proot)) for pid, proot in roster),
     ).write(path)
 

--- a/tests/test_plugin_packs.py
+++ b/tests/test_plugin_packs.py
@@ -86,14 +86,16 @@ def fake_claude(
     calls: Path,
     returncode: int = 0,
     raw_stdout: str | None = None,
+    delay: float = 0.0,
 ) -> Path:
     """An executable ``claude`` shim: appends to ``calls`` per invocation and prints the roster JSON."""
     bindir.mkdir(parents=True, exist_ok=True)
     payload = raw_stdout if raw_stdout is not None else json.dumps(roster or [])
     (script := bindir / "claude").write_text(
         f"#!{sys.executable}\n"
-        "import sys, pathlib\n"
+        "import sys, pathlib, time\n"
         f"pathlib.Path({str(calls)!r}).open('a').write('x')\n"
+        f"time.sleep({delay!r})\n"
         f"sys.stdout.write({payload!r})\n"
         f"sys.exit({returncode})\n"
     )
@@ -109,9 +111,21 @@ def install_claude(
     roster: list[dict[str, object]] | None = None,
     returncode: int = 0,
     raw_stdout: str | None = None,
+    delay: float = 0.0,
 ) -> None:
-    bindir = fake_claude(tmp / "bin", roster, calls=calls, returncode=returncode, raw_stdout=raw_stdout)
+    bindir = fake_claude(tmp / "bin", roster, calls=calls, returncode=returncode, raw_stdout=raw_stdout, delay=delay)
     monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+
+
+def settle_refresh(timeout: float = 20.0) -> None:
+    """Wait out any background roster refresh, so an assertion sees the settled snapshot."""
+    deadline = time.monotonic() + timeout
+    while plugins.REFRESHING and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+
+def enable_marker(value: str) -> str:
+    return json.dumps({"enabledPlugins": {"marker@mkt": value}})
 
 
 def plant_installed() -> None:
@@ -377,32 +391,72 @@ def test_refresh_on_each_watched_change(tmp_path: Path, monkeypatch: pytest.Monk
     if not (watched.is_relative_to(root) or watched.is_relative_to(resolve_claude_config_dir())):
         pytest.skip(f"{watched} is an absolute managed-settings system path — not sandbox-writable")
     watched.parent.mkdir(parents=True, exist_ok=True)
-    watched.write_text("x" * 500)  # absent -> present, or a size bump: either moves the stat tuple
+    watched.write_text("x" * 500 if watched == plugins.installed_plugins_path() else enable_marker("on"))
+    plugins.enabled_plugins(root)
+    settle_refresh()
     plugins.enabled_plugins(root)
     assert calls.read_text() == "xx"  # the watched-file change re-ran the CLI
 
 
-def test_ctime_only_watched_rewrite_refreshes_roster(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A same-size, mtime-restored rewrite of a watched settings file moves only ctime; without ctime in
-    # the stat record the snapshot would stay "fresh" and miss a plugin enable/disable landing that way.
+def test_mtime_restored_enablement_rewrite_refreshes_roster(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # An enable/disable can land as a same-size rewrite with mtime restored, moving neither size nor
+    # mtime; the digest reads the key itself, so it is caught however the file was written.
     plant_installed()
     (root := tmp_path / "proj").mkdir()
     calls = tmp_path / "calls"
     settings = root / ".claude" / "settings.json"
     settings.parent.mkdir(parents=True, exist_ok=True)
-    settings.write_text('{"a": 1}')
+    settings.write_text(enable_marker("on_"))
     plugin = write_plugin_pack(tmp_path, "show", "1.0.0")
     install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", plugin)])
 
     plugins.enabled_plugins(root)
     assert calls.read_text() == "x"
     st = settings.stat()
-    settings.write_text('{"b": 2}')  # same byte length, different content
-    os.utime(settings, ns=(st.st_atime_ns, st.st_mtime_ns))  # restore mtime; only ctime moves
+    settings.write_text(enable_marker("off"))  # same byte length, different enablement
+    os.utime(settings, ns=(st.st_atime_ns, st.st_mtime_ns))
     after = settings.stat()
     assert after.st_size == st.st_size and after.st_mtime_ns == st.st_mtime_ns
     plugins.enabled_plugins(root)
-    assert calls.read_text() == "xx"  # ctime move re-ran the CLI
+    settle_refresh()
+    plugins.enabled_plugins(root)
+    assert calls.read_text() == "xx"  # the enablement change re-ran the CLI
+
+
+def test_settings_rewrite_that_cannot_change_enablement_serves_the_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The whole point of the digest: a session rewriting its settings for reasons that have nothing to
+    # do with plugins used to cost every root a Node spawn.
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(json.dumps({"model": "opus", "enabledPlugins": {"marker@mkt": "on"}}))
+    plugin = write_plugin_pack(tmp_path, "show", "1.0.0")
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", plugin)])
+
+    plugins.enabled_plugins(root)
+    assert calls.read_text() == "x"
+    settings.write_text(json.dumps({"model": "sonnet", "effortLevel": "high", "enabledPlugins": {"marker@mkt": "on"}}))
+    plugins.enabled_plugins(root)
+    settle_refresh()
+    plugins.enabled_plugins(root)
+    assert calls.read_text() == "x"  # never re-ran: enablement is untouched
+
+
+def test_unparseable_settings_still_invalidate_coarsely(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A file the digest cannot read falls back to its stat, so a corrupt settings file never reads as
+    # "declares no plugins" and quietly pins a stale roster.
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text("{not json")
+    before = plugins.fingerprint(root)
+    settings.write_text("{still not json, but longer}")
+    assert plugins.fingerprint(root) != before
 
 
 @pytest.mark.parametrize(
@@ -538,18 +592,18 @@ def test_managed_settings_dropin_changes_invalidate_snapshot(tmp_path: Path) -> 
     # drop-in moves the stat tuple, invalidating a stale roster snapshot.
     (root := tmp_path / "proj").mkdir()
     dropin = resolve_claude_config_dir() / "managed-settings.d"
-    absent = plugins.stat_records(root)
+    absent = plugins.fingerprint(root)
 
     dropin.mkdir(parents=True)
-    (drop := dropin / "10-policy.json").write_text('{"a": 1}')
-    added = plugins.stat_records(root)
-    assert added != absent  # a new drop-in moves the stat tuple
+    (drop := dropin / "10-policy.json").write_text(enable_marker("on"))
+    added = plugins.fingerprint(root)
+    assert added != absent  # a new drop-in moves the fingerprint
 
-    drop.write_text('{"policy": "changed and now longer"}')  # different byte length
-    assert plugins.stat_records(root) != added  # editing a drop-in moves it
+    drop.write_text(enable_marker("off"))
+    assert plugins.fingerprint(root) != added  # editing a drop-in moves it
 
     drop.unlink()
-    assert plugins.stat_records(root) != added  # removing the drop-in moves it back off
+    assert plugins.fingerprint(root) != added  # removing the drop-in moves it back off
 
 
 @pytest.mark.parametrize(
@@ -646,6 +700,8 @@ def test_newer_plugin_version_rebinds(tmp_path: Path, monkeypatch: pytest.Monkey
     install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", v2, version="2.0.0")])
     plugins.installed_plugins_path().write_text("x" * 500)
 
+    plugins.enabled_plugins(root)
+    settle_refresh()
     (second,) = plugins.resolve_plugin_packs(root)
     assert second.entry.root == str(v2)
     assert second.path == v2 / manager.PLUGIN_PACK_DIRNAME / manager.HOOKS_DIRNAME
@@ -926,3 +982,83 @@ def test_gate_admits_exactly_its_width_at_once(tmp_path: Path, monkeypatch: pyte
     assert entered.wait(timeout=10)
     for thread in [*holders, extra]:
         thread.join(timeout=10)
+
+
+def test_root_with_no_snapshot_blocks_on_the_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Nothing to serve, and an empty roster is the forbidden collapse — a first-ever root must wait.
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    plugin = write_plugin_pack(tmp_path, "show", "1.0.0")
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", plugin)], delay=1.0)
+
+    started = time.monotonic()
+    (only,) = plugins.enabled_plugins(root)
+    assert time.monotonic() - started >= 1.0  # it waited for the answer rather than guessing
+    assert only.id == "mkt/show"
+    assert calls.read_text() == "x"
+
+
+def test_stale_snapshot_is_served_without_waiting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    v1 = write_plugin_pack(tmp_path, "show", "1.0.0")
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", v1)])
+    (first,) = plugins.enabled_plugins(root)
+
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(enable_marker("flipped"))
+    v2 = write_plugin_pack(tmp_path, "other", "1.0.0", slot="other")
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/other", v2)], delay=2.0)
+
+    started = time.monotonic()
+    (served,) = plugins.enabled_plugins(root)
+    assert time.monotonic() - started < 1.0  # the stale snapshot came back, the 2s spawn ran behind it
+    assert served.id == first.id == "mkt/show"
+
+    settle_refresh()
+    (refreshed,) = plugins.enabled_plugins(root)
+    assert refreshed.id == "mkt/other"  # one event later, the refresh has landed
+
+
+def test_background_refresh_does_not_stack_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    plugin = write_plugin_pack(tmp_path, "show", "1.0.0")
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", plugin)])
+    plugins.enabled_plugins(root)
+
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(enable_marker("flipped"))
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", plugin)], delay=1.0)
+    for _ in range(5):
+        plugins.enabled_plugins(root)
+    settle_refresh()
+    assert calls.read_text() == "xx"  # five stale reads, one refresh spawn
+
+
+def test_failed_background_refresh_records_and_stops_respawning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plant_installed()
+    (root := tmp_path / "proj").mkdir()
+    calls = tmp_path / "calls"
+    plugin = write_plugin_pack(tmp_path, "show", "1.0.0")
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[roster_entry("mkt/show", plugin)])
+    plugins.enabled_plugins(root)
+
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(enable_marker("flipped"))
+    install_claude(tmp_path, monkeypatch, calls=calls, roster=[], returncode=1)
+    for _ in range(4):
+        plugins.enabled_plugins(root)
+        settle_refresh()
+
+    assert plugins.failure_path(root).exists()  # the failure was recorded, not swallowed
+    assert calls.read_text() == "xx"  # and the record stopped the retries
+    assert plugins.enabled_plugins(root)  # the stale snapshot is still served throughout


### PR DESCRIPTION
## Context

A cold capt-hook dispatch measured about 10s wall for 0.3s of real work. Profiling put almost none of it on the worker: boot is 0.165s. The cost was `claude plugin list --json`, 3.3s of Node start, re-run for any root whose plugin snapshot had been invalidated. The cold path broke down as roughly 1.6s launcher, 0.2s boot, 3.3s roster, 0.3s work.

The invalidation was far too eager. `captain_hook/packs/plugins.py` keyed the snapshot on a stat tuple over machine-wide files, so a write to `~/.claude/settings.json` that touched nothing plugin-related still cost every root on the machine a fresh 3.3s spawn. Claude Code rewrites settings constantly, and with many concurrent sessions that one trigger dominated.

Two changes, plus one unrelated small fix.

## Summary

**Invalidate only when enablement can actually have changed.** The stat-tuple test becomes a normalized digest over only the settings keys that decide the roster: `PLUGIN_SETTINGS_KEYS` (`plugins.py:60`), `settings_record` (`:121`), `fingerprint` (`:155`).

The key list was established empirically, not by reasoning. Running `claude plugin list --json` on a scratch root and diffing every roster field, id through installPath and version, across edits: `enabledPlugins` moves the roster; `model`, `effortLevel`, `alwaysThinkingEnabled`, `permissions`, `hooks`, and `env` do not. `extraKnownMarketplaces` provably cannot move the roster on its own, since a plugin installed from a new marketplace also rewrites `installed_plugins.json`. It is digested anyway, on an asymmetry: one rare extra invalidation costs nothing, while a wrong omission serves a stale roster as fresh.

`installed_plugins.json` deliberately stays a coarse stat trigger instead of joining the digest. Its format is undocumented and this module has never parsed it, so a digest could silently miss a field that moves the roster. It also changes only on install, update, or remove, rare enough that invalidating every root on it costs nothing.

Two guards against the silent-wrong-answer class. An unparseable or non-object settings file falls back to `stat_record`, so a corrupt file never reads as "declares no plugins". And `SNAPSHOT_VERSION` is bumped 2 to 3, so no snapshot written under the old meaning is ever served.

The residual risk, stated plainly: the allowlist is empirical against today's CLI, not a documented contract. If Claude Code adds a settings key that affects enablement, the digest misses it and serves a stale roster. A denylist would fail safe but would re-admit exactly the churn this fixes.

**Serve stale, refresh behind.** `enabled_plugins` (`plugins.py:498`) now returns an existing snapshot immediately and calls `refresh_behind` (`:471`) when it is stale. `resolve_roster` (`:532`) is the only blocking path, reached only when there is no snapshot at all: a root with nothing cached still blocks, because serving an empty roster would be the collapse `RosterFailure` exists to prevent. One refresh in flight per root, via `REFRESHING` and `REFRESHING_GUARD` (`:61-62`). The refresh thread goes through the existing `roster_gate`, since it calls the same `resolve_roster`. A failure records `RosterFailure` or `RosterOutage` as any other spawn would, and that record is also what stops it retrying: the next attempt reads it and returns without spawning until it expires.

Measured against the real CLI on a scratch root:

```
3.326s  cold, no snapshot                    (still blocks, correct)
0.001s  warm, fresh snapshot
0.001s  after an UNRELATED settings rewrite  (was 3.3s; the digest)
0.001s  after an ENABLEMENT change           (was 3.3s; refresh ran behind)
0.001s  next event, refresh landed
```

Combined, in steady state neither fires, because settings churn no longer invalidates. On a genuine enable, disable, or install, one event serves the previous roster and the next is current: one event of staleness, on an action the user just took. A root's first-ever dispatch still blocks once. Net, the 3.3s moves from "every root, on every machine-wide settings write" to "once per root, ever".

**`registry.py:81,84`.** `_claude_stats` had the identical intent as the snapshot fingerprint, so it now shares the digest and gets the same win.

**Unrelated small fix in the same branch.** `userpath.py:36` raises `REFRESH_TIMEOUT_SECONDS` from 1 to 3. The login-shell probe measures 1.43 to 1.50s on a fish shell, so the 12h cache could never refresh: every attempt timed out and fell back, burning a wasted second per cold worker.

## Deployment

`SNAPSHOT_VERSION` 2 to 3 discards every cached snapshot; the machine this was developed on holds 3567, all v2. So the first dispatch per root after the upgrade blocks about 3.3s, and on a machine with many live sessions those land together. `roster_gate` bounds them to 4 concurrent, so it drains instead of stampeding, but the first prompt in each session after the upgrade is slow once. That is inherent to changing what the fingerprint means: serving a snapshot written under the old meaning is exactly what the version gate exists to prevent.

## Verification

```
uv run pytest                                          4136 passed, 6 skipped in 300.96s
uv run ruff check captain_hook/ tests/                 All checks passed!
uv run ruff format --check <6 files>                   6 files already formatted
go build ./... && go test ./internal/hookd/ -count=1   ok 0.589s
```

The 6 skips are pre-existing: unwritable managed-settings system paths, and two tutorial-parity skips. No Go files changed; the Go suite ran only to prove nothing broke.

New in `tests/test_plugin_packs.py`:

- `test_root_with_no_snapshot_blocks_on_the_cli` (`:987`) proves the no-snapshot path waits, via a shim with a real 1s delay.
- `test_stale_snapshot_is_served_without_waiting` (`:1002`) returns in under 1s against a 2s spawn, then the refresh lands.
- `test_background_refresh_does_not_stack_up` (`:1026`): five stale reads, one spawn.
- `test_failed_background_refresh_records_and_stops_respawning` (`:1044`).
- `test_settings_rewrite_that_cannot_change_enablement_serves_the_snapshot` (`:426`).
- `test_unparseable_settings_still_invalidate_coarsely` (`:449`).

`test_ctime_only_watched_rewrite_refreshes_roster` was rewritten as `test_mtime_restored_enablement_rewrite_refreshes_roster` (`:401`) rather than deleted. Its old premise, that any same-size rewrite invalidates, is exactly what the digest intentionally changes, so it now proves the digest catches an enablement edit however the file was written.

The three headline behaviours were mutation-tested rather than trusted green: removing the stale-serve fails the no-waiting test, serving empty instead of blocking fails the no-snapshot test, and reverting the digest fails the unrelated-rewrite test. CI runs the full suite on this push.

https://claude.ai/code/session_01UyGU5fdNbhFe2sC7V1KZin
