### PR TITLE
fix(hookd): one session's failure no longer retires the worker every session shares

### DIFF
--- a/internal/hookd/daemon.go
+++ b/internal/hookd/daemon.go
@@ -12,7 +12,11 @@ const (
 	helperSigningIdentifier       = "com.yasyf.capt-hook.helper"
 	helperClientSigningIdentifier = "com.yasyf.capt-hook.helper.bridge"
 	hostShutdownTimeout           = 30 * time.Second
-	hostConcurrency               = 64
+	// hostConcurrency bounds concurrent wire sessions, not dispatch. Every
+	// resident client holds one for its lifetime — an MCP server per Claude
+	// Code session, plus each in-flight hook — so it tracks the machine's
+	// session count rather than its cores.
+	hostConcurrency = 256
 )
 
 func hostRequirement() daemonkit.Requirement {

--- a/internal/hookd/manager.go
+++ b/internal/hookd/manager.go
@@ -159,6 +159,9 @@ func (m *workerManager) dispatch(ctx context.Context, request EventRequest) (Eve
 		worker := entry.worker
 		response, err := worker.call(ctx, request)
 		if err != nil {
+			if !worker.broken() {
+				return EventResponse{}, err
+			}
 			m.retire(key.id, worker)
 			return EventResponse{}, errors.Join(err, m.settle(worker))
 		}

--- a/internal/hookd/worker.go
+++ b/internal/hookd/worker.go
@@ -77,14 +77,28 @@ func (w *workerClient) call(ctx context.Context, request EventRequest) (EventRes
 
 	if err := w.write(ctx, workerFrame{Protocol: Schema, Op: "event", ID: id, Request: &request}); err != nil {
 		w.removePending(id)
+		if !errors.Is(err, ErrPayloadTooLarge) {
+			w.fail(err)
+		}
 		return EventResponse{}, err
 	}
 	select {
 	case received := <-result:
 		return received.response, received.err
 	case <-ctx.Done():
+		w.removePending(id)
 		return EventResponse{}, ctx.Err()
 	}
+}
+
+// broken reports whether the transport itself failed, which a caller's own
+// expired deadline and a hook's own error both produce a call error without.
+// Workers are shared across sessions, so retiring one on either of those takes
+// down every other session mid-call.
+func (w *workerClient) broken() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
 }
 
 func (w *workerClient) write(ctx context.Context, frame workerFrame) error {

--- a/internal/hookd/worker_sharing_test.go
+++ b/internal/hookd/worker_sharing_test.go
@@ -1,0 +1,145 @@
+package hookd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func silentWorker(t *testing.T) (*workerClient, net.Conn) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	go func() {
+		hello, err := decodeWorkerFrame(serverConn)
+		if err != nil {
+			return
+		}
+		_ = encodeWorkerFrame(serverConn, workerFrame{Protocol: Schema, Op: "hello", Build: hello.Build})
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	worker, err := handshakeWorker(ctx, clientConn, "12.9.1")
+	if err != nil {
+		t.Fatalf("handshakeWorker: %v", err)
+	}
+	return worker, serverConn
+}
+
+func TestCallerTimeoutLeavesTheWorkerUsable(t *testing.T) {
+	t.Parallel()
+	worker, serverConn := silentWorker(t)
+	go func() {
+		for {
+			if _, err := decodeWorkerFrame(serverConn); err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := worker.call(ctx, testEventRequest("PreToolUse")); err == nil {
+		t.Fatal("call against a worker that never answers succeeded")
+	}
+
+	if worker.broken() {
+		t.Fatal("one caller's expired deadline broke the worker every other session shares")
+	}
+	worker.mu.Lock()
+	pending := len(worker.pending)
+	worker.mu.Unlock()
+	if pending != 0 {
+		t.Fatalf("pending after a caller timeout = %d, want 0; the entry leaks until the worker dies", pending)
+	}
+}
+
+func TestProductErrorLeavesTheWorkerUsable(t *testing.T) {
+	t.Parallel()
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	go func() {
+		hello, err := decodeWorkerFrame(serverConn)
+		if err != nil {
+			return
+		}
+		_ = encodeWorkerFrame(serverConn, workerFrame{Protocol: Schema, Op: "hello", Build: hello.Build})
+		first, err := decodeWorkerFrame(serverConn)
+		if err != nil {
+			return
+		}
+		_ = encodeWorkerFrame(serverConn, workerFrame{
+			Protocol: Schema, Op: "error", ID: first.ID, Error: "a hook raised",
+		})
+		second, err := decodeWorkerFrame(serverConn)
+		if err != nil {
+			return
+		}
+		_ = encodeWorkerFrame(serverConn, workerFrame{
+			Protocol: Schema, Op: "result", ID: second.ID,
+			Response: &EventResponse{Schema: Schema, Status: "ok", Stdout: "second"},
+		})
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	worker, err := handshakeWorker(ctx, clientConn, "12.9.1")
+	if err != nil {
+		t.Fatalf("handshakeWorker: %v", err)
+	}
+
+	if _, err := worker.call(ctx, testEventRequest("PreToolUse")); err == nil {
+		t.Fatal("a worker error frame returned no error")
+	}
+	if worker.broken() {
+		t.Fatal("one hook's exception broke the interpreter every other session shares")
+	}
+
+	response, err := worker.call(ctx, testEventRequest("PostToolUse"))
+	if err != nil {
+		t.Fatalf("second call after a product error = %v, want success", err)
+	}
+	if response.Stdout != "second" {
+		t.Fatalf("Stdout = %q, want %q", response.Stdout, "second")
+	}
+}
+
+func TestOversizePayloadLeavesTheWorkerUsable(t *testing.T) {
+	t.Parallel()
+	worker, serverConn := silentWorker(t)
+	go func() {
+		for {
+			if _, err := decodeWorkerFrame(serverConn); err != nil {
+				return
+			}
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	oversize := testEventRequest("PreToolUse")
+	oversize.PayloadRaw = strings.Repeat("x", maxWorkerFrame+1)
+	if _, err := worker.call(ctx, oversize); !errors.Is(err, ErrPayloadTooLarge) {
+		t.Fatalf("call with an oversize payload = %v, want ErrPayloadTooLarge", err)
+	}
+	if worker.broken() {
+		t.Fatal("one oversize payload broke the interpreter every other session shares")
+	}
+}
+
+func TestTransportFailureMarksTheWorkerBroken(t *testing.T) {
+	t.Parallel()
+	worker, serverConn := silentWorker(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = serverConn.Close()
+	if _, err := worker.call(ctx, testEventRequest("PreToolUse")); err == nil {
+		t.Fatal("call over a severed transport succeeded")
+	}
+	if !worker.broken() {
+		t.Fatal("a severed transport left the worker reading as usable")
+	}
+}


### PR DESCRIPTION
Python workers are cached per `{root, python, build, env}` and **shared across every Claude Code session that hits the same key**. `dispatch` retired that shared worker on *any* call error, and `workerClient.fail` sweeps every pending waiter with `net.ErrClosed`. So one session's bad luck killed every other session's in-flight call, surfacing as:

```
Failed with non-blocking status code: use of closed network connection
```

Three distinct causes reached that retire, and only the third deserved it.

## A caller's own deadline

`call`'s `<-ctx.Done()` arm returns `ctx.Err()`. That is the caller's clock running out, not evidence about the worker — but `dispatch` read it as a dead worker and retired the interpreter every other session was mid-call on.

It also returned without `removePending(id)`, so the pending entry leaked until the worker died.

## A hook's own exception

`readLoop` delivers an `error` frame to its waiter and deliberately does **not** fail the worker — the interpreter is fine, one hook raised. `call` returns that error, and `dispatch` retired the interpreter anyway. A single Python exception in one repo's hook took down every other session sharing that worker.

## A severed transport

This one is real, and it has to keep working. `call` returned a write error without failing the worker, leaving it to `readLoop` to notice asynchronously. Gating the retire on worker state alone would have left a dead worker cached and every later call failing against it.

## The fix

`workerClient.broken()` asks the transport instead of inferring from the error — the same distinction daemonkit's own `retiring()` draws, for the same reason. `dispatch` retires only a worker that is actually broken.

A failed write now fails the worker, since a half-written frame desyncs the stream whatever caused it — except `ErrPayloadTooLarge`, which is refused before a byte is written and must not cost other sessions their interpreter.

Four tests, each failing before the change:

- `TestCallerTimeoutLeavesTheWorkerUsable` — also asserts the pending map is empty; without the fix it reads 1.
- `TestProductErrorLeavesTheWorkerUsable` — a second call on the same worker succeeds after an error frame.
- `TestOversizePayloadLeavesTheWorkerUsable` — the oversize refusal is not fatal to the worker.
- `TestTransportFailureMarksTheWorkerBroken` — the case that must still retire.

`TestWorkerProtocolViolationFailsEveryPendingCall` stays green: a genuine protocol violation *should* still sweep everyone.

## Capacity ceiling

`hostConcurrency` goes 64 → 256. It bounds concurrent wire sessions, not dispatch: every resident client holds one for its lifetime — an MCP server per Claude Code session plus each in-flight hook — so it tracks session count, not cores. On a machine running ~20 sessions the old ceiling was reached, and once reached nothing released a slot.

This is margin, not the fix. The reclaim that returns a quiet peer's slot is daemonkit#7; adopting it here needs the release that carries it, and this PR does not bump `go.mod`.

## Still to come

Classifying `ErrSessionCapacity` in `probeFailure` — today capacity exhaustion is reported as `signed host is not installed and ready; run capt-hook helper install`, which names an unrelated remedy — needs `daemonkit.ErrSessionCapacity` from that same release. It follows in its own PR.

## Verification

`go test ./internal/hookd/` and `go test -race ./internal/hookd/` green.

https://claude.ai/code/session_012P3cgojXsje6g5RZXW2URE
