### PR TITLE
ci: run the Go test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  go-test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.5
+
+      - name: Test capt-hookd
+        run: go test -race -count=1 ./...
+
   helper-test:
     runs-on: macos-15
     steps:


### PR DESCRIPTION
captain-hook has 48 top-level Go tests under `internal/hookd/` and nothing ran them in CI. The `helper-test` job compiles `capt-hookd` via `build-capt-hookd.sh`, but compiling is not testing. This adds a `go-test` job.

Three judgement calls worth stating:

**`macos-15`, not ubuntu.** The tree does not build off darwin: `GOOS=linux go build ./...` fails with `imports github.com/yasyf/daemonkit/launchd: build constraints exclude all Go files`. It also matches the runner `helper-test` already uses.

**`go-version: 1.26.5` hardcoded rather than `go-version-file: go.mod`.** The file's other two Go jobs both hardcode 1.26.5, while `go.mod` says `go 1.26.3` with no `toolchain` line — reading from go.mod would *downgrade* the CI toolchain. Moving the repo to `go-version-file` is a separate change.

**`-count=1`.** `actions/setup-go@v6` restores `GOCACHE` by default, so a re-run on an unchanged tree could serve a cached PASS.

## Proof it grades results

The workflow triggers on push-to-main and `pull_request`, so a branch push alone fires nothing. `push.branches` was temporarily widened to get real runs, then stripped; this branch is one clean commit.

| Run | `go-test` | Evidence |
|---|---|---|
| 34654840862 | success | `ok .../internal/hookd 16.975s`, not `(cached)` |
| 34655169272 | **failure** | `--- FAIL: TestWriteAllHandlesShortWrites` |
| 34655480335 | success | 75 `--- PASS`, 0 `--- FAIL` |

The red run came from a `t.Fatalf` planted in `internal/hookd/protocol_test.go:134`. **Only `go-test` failed** — `helper-test`, `test (3.13)` and `descriptor` all stayed green, so the job grades test results rather than inheriting another job's failure. CI logs show 48 top-level and 75 total tests, identical on the red and green runs, so the whole suite runs rather than a subset.

## Scope

daemonkit is deliberately not covered here. It already runs `./scripts/test.sh -race ./...` in its own CI (18 packages, `internal/wire` included), and captain-hook pins `daemonkit v0.23.0` with no `replace` — so running its suite from here would grade a published release its own CI already graded, and decouple this CI from the pin it ships against.

A known residual, left as-is: captain-hook's CI grades against the pin while daemonkit's `main` moves on, so only a version-bump PR surfaces an incompatibility. That is the honest behaviour of a pin.

No `go vet` step (a different check), no `timeout-minutes` (no job in this file has one), and no explicit `cache:` (defaulted on by `setup-go@v6`). captain-hook needs no `scripts/test.sh` equivalent — unlike daemonkit, none of its tests spawn processes.

https://claude.ai/code/session_012P3cgojXsje6g5RZXW2URE
