### PR TITLE
bench: ⚗️ measure dispatch latency and execve count per event

### DIFF
--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,0 +1,95 @@
+{
+  "machine": {
+    "recorded": "2026-09-11T23:16:49Z",
+    "build": "12.26.0",
+    "os": "Darwin 25.6.0",
+    "arch": "arm64",
+    "endpoint_security_toll_us": 4.1
+  },
+  "records": [
+    {
+      "label": "chain-warm",
+      "execs": 2,
+      "exec_floor": 2,
+      "confirmations": 7,
+      "confidence": 0.9941,
+      "quiet_fraction": 0.0485,
+      "samples": 103,
+      "ms_min": 65.9,
+      "ms_median": 129.35,
+      "ms_p90": 501.18
+    },
+    {
+      "label": "chain-cold",
+      "execs": null,
+      "exec_floor": 41,
+      "confirmations": 1,
+      "confidence": 0.0,
+      "quiet_fraction": 0.0,
+      "samples": 24,
+      "ms_min": 675.46,
+      "ms_median": 843.83,
+      "ms_p90": 2258.77
+    },
+    {
+      "label": "host-warm",
+      "execs": 1,
+      "exec_floor": 1,
+      "confirmations": 5,
+      "confidence": 0.995,
+      "quiet_fraction": 0.1111,
+      "samples": 45,
+      "ms_min": 32.0,
+      "ms_median": 42.83,
+      "ms_p90": 88.28
+    },
+    {
+      "label": "host-cold",
+      "execs": null,
+      "exec_floor": 14,
+      "confirmations": 1,
+      "confidence": 0.0,
+      "quiet_fraction": 0.0,
+      "samples": 19,
+      "ms_min": 632.99,
+      "ms_median": 913.2,
+      "ms_p90": 5310.94
+    },
+    {
+      "label": "interpreter-bare",
+      "execs": 1,
+      "exec_floor": 1,
+      "confirmations": 4,
+      "confidence": 0.9937,
+      "quiet_fraction": 0.0255,
+      "samples": 196,
+      "ms_min": 22.9,
+      "ms_median": 230.11,
+      "ms_p90": 343.23
+    },
+    {
+      "label": "interpreter-client",
+      "execs": 1,
+      "exec_floor": 1,
+      "confirmations": 3,
+      "confidence": 1.0,
+      "quiet_fraction": 0.0109,
+      "samples": 916,
+      "ms_min": 40.52,
+      "ms_median": 87.54,
+      "ms_p90": 254.5
+    },
+    {
+      "label": "host-version",
+      "execs": 1,
+      "exec_floor": 1,
+      "confirmations": 8,
+      "confidence": 0.9953,
+      "quiet_fraction": 0.1282,
+      "samples": 39,
+      "ms_min": 5.35,
+      "ms_median": 6.78,
+      "ms_p90": 8.51
+    }
+  ]
+}

--- a/bench/cli.py
+++ b/bench/cli.py
@@ -1,0 +1,47 @@
+"""The benchmark runner: ``uv run python -m bench.cli run [--record]``.
+
+Run it from an otherwise idle machine. The exec counter is system-wide, so a
+concurrent Claude Code session — which fires this very chain on every tool call —
+is the loudest neighbour there is, and it shows up as a nonzero noise floor and a
+scenario whose count comes back ``unquiet`` rather than as a wrong number.
+"""
+
+from __future__ import annotations
+
+import click
+
+from bench.dispatch import deployment, roots, scenarios
+from bench.measure import measure
+from bench.report import Record, record, table, write_baseline
+
+
+@click.group()
+def cli() -> None:
+    """Dispatch-latency and execve-count benchmarks for the capt-hook hot path."""
+
+
+@cli.command()
+@click.option("--budget", default=20.0, help="Seconds a scenario may sample for; a cold one is capped lower.")
+@click.option("--record", "persist", is_flag=True, default=False, help="Overwrite bench/baseline.json with this run.")
+def run(budget: float, persist: bool) -> None:
+    """Measure every scenario and print the table, optionally recording it as the baseline."""
+    deployed = deployment()
+    click.echo(f"build {deployed.build} via {deployed.client}")
+    with roots() as (warm, cold):
+        records: list[Record] = []
+        for scenario in scenarios(deployed, warm, cold, budget_s=budget):
+            measurement = measure(
+                scenario.label,
+                scenario.command,
+                budget_s=scenario.budget_s,
+                minimum_samples=scenario.minimum_samples,
+            )
+            records.append(record(measurement))
+            click.echo(f"  {scenario.label:20s} {records[-1].execs} execs  {records[-1].ms_min} ms")
+    click.echo(table(records))
+    if persist:
+        click.echo(f"recorded -> {write_baseline(records, build=deployed.build)}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/bench/counter.py
+++ b/bench/counter.py
@@ -1,0 +1,37 @@
+"""The machine's own execve counter, read straight out of the kernel.
+
+``security.mac.asp.stats.exec_hook_count`` is a monotonic system-wide count of MAC
+exec-hook invocations — one per ``execve`` — and unlike dtrace, ``eslogger`` and the
+BSM audit trail it is readable without root on a SIP-enabled machine. Reading it
+costs no process of its own, so a measurement window does not perturb what it
+measures. It is system-wide, though: a window also counts whatever else the machine
+execs while it is open, which is what :mod:`bench.measure` pairs idle windows against.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+
+EXEC_HOOK_COUNT = b"security.mac.asp.stats.exec_hook_count"
+EXEC_HOOK_SLEEP = b"security.mac.asp.stats.exec_hook_sleep_time"
+
+LIBC = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+
+def counter(name: bytes) -> int:
+    value = ctypes.c_uint64()
+    size = ctypes.c_size_t(ctypes.sizeof(value))
+    if LIBC.sysctlbyname(name, ctypes.byref(value), ctypes.byref(size), None, 0) != 0:
+        raise OSError(ctypes.get_errno(), f"sysctlbyname {name.decode()}")
+    return value.value
+
+
+def execs() -> int:
+    """The machine's execve count since boot."""
+    return counter(EXEC_HOOK_COUNT)
+
+
+def endpoint_security_toll_us() -> float:
+    """Mean microseconds an exec has spent parked in the endpoint-security hook since boot."""
+    return counter(EXEC_HOOK_SLEEP) / 1000 / counter(EXEC_HOOK_COUNT)

--- a/bench/dispatch.py
+++ b/bench/dispatch.py
@@ -1,0 +1,134 @@
+"""The dispatch chain under test, and the roots that make a dispatch cold or warm.
+
+The daemon caches one Python worker per ``{root, python, build, environment}`` tuple
+and retires the entry the moment its dispatch finishes when the root lives under the
+system temp directory (``ephemeralRoot``, ``internal/hookd/manager.go``). A scratch
+root there is therefore cold on every dispatch and a root outside it is warm from the
+second one on, which is the whole cold/warm control this harness needs — no worker
+restart, and nothing touched in the live daemon that its own idle sweep will not reclaim.
+
+Both benchmark roots are empty, so what the scenarios time is the framework's dispatch
+overhead rather than the bodies of whichever hooks a real project happens to declare.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from bench.measure import Command
+from capt_hook_client.client import HOST
+
+BENCH_ROOT = Path.home() / ".cache" / "capt-hook-bench"
+COLD_BUDGET_S = 60.0
+EVENT = "PostToolUse"
+
+
+class DeploymentMissing(RuntimeError):
+    """No `hook` on PATH is the deployment the signed host will serve."""
+
+
+@dataclass(frozen=True, slots=True)
+class Deployment:
+    client: Path
+    interpreter: Path
+    build: str
+
+
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    label: str
+    command: Command
+    budget_s: float
+    minimum_samples: int
+
+
+def host_build() -> str:
+    return json.loads(subprocess.run([HOST, "version"], capture_output=True, text=True, check=True).stdout)["build"]
+
+
+def shebang(script: Path) -> Path:
+    return Path(script.read_text().splitlines()[0].removeprefix("#!").strip())
+
+
+def dist_version(interpreter: Path) -> str:
+    probe = "import importlib.metadata; print(importlib.metadata.version('capt-hook'))"
+    return subprocess.run([interpreter, "-c", probe], capture_output=True, text=True).stdout.strip()
+
+
+def clients() -> list[Path]:
+    return [script for directory in os.get_exec_path() if (script := Path(directory) / "hook").is_file()]
+
+
+def deployment() -> Deployment:
+    """The `hook` console script whose distribution is the exact build the signed host serves."""
+    build = host_build()
+    for client in clients():
+        if dist_version(interpreter := shebang(client)) == build:
+            return Deployment(client=client, interpreter=interpreter, build=build)
+    raise DeploymentMissing(f"no `hook` on PATH carries build {build}; searched {[str(c) for c in clients()]}")
+
+
+def payload(root: Path) -> bytes:
+    return json.dumps(
+        {
+            "session_id": "bench",
+            "transcript_path": "/dev/null",
+            "cwd": str(root),
+            "hook_event_name": EVENT,
+            "tool_name": "Bash",
+            "tool_input": {"command": "true"},
+            "tool_response": {},
+        }
+    ).encode()
+
+
+def chain(deployed: Deployment, root: Path) -> Command:
+    return Command((str(deployed.client), "--root", str(root), "run", EVENT), payload(root))
+
+
+def host(deployed: Deployment, root: Path) -> Command:
+    return Command(
+        (
+            HOST,
+            "run",
+            "--event",
+            EVENT,
+            "--root",
+            str(root),
+            "--cwd",
+            os.getcwd(),
+            "--python",
+            str(deployed.interpreter),
+            "--build",
+            deployed.build,
+        ),
+        payload(root),
+    )
+
+
+@contextmanager
+def roots() -> Iterator[tuple[Path, Path]]:
+    warm = BENCH_ROOT / "warm"
+    warm.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="capt-hook-bench-cold-") as cold:
+        yield warm, Path(cold)
+
+
+def scenarios(deployed: Deployment, warm: Path, cold: Path, *, budget_s: float) -> tuple[Scenario, ...]:
+    interpreter = str(deployed.interpreter)
+    return (
+        Scenario("chain-warm", chain(deployed, warm), budget_s, 30),
+        Scenario("chain-cold", chain(deployed, cold), min(budget_s, COLD_BUDGET_S), 10),
+        Scenario("host-warm", host(deployed, warm), budget_s, 30),
+        Scenario("host-cold", host(deployed, cold), min(budget_s, COLD_BUDGET_S), 10),
+        Scenario("interpreter-bare", Command((interpreter, "-c", "pass")), budget_s, 30),
+        Scenario("interpreter-client", Command((interpreter, "-c", "import capt_hook_client.client")), budget_s, 30),
+        Scenario("host-version", Command((HOST, "version")), budget_s, 30),
+    )

--- a/bench/measure.py
+++ b/bench/measure.py
@@ -1,0 +1,161 @@
+"""Paired-window measurement: one execve count and one wall time per sample.
+
+The kernel counter :mod:`bench.counter` reads is system-wide, so a window around a
+command also counts whatever else the machine execs while it is open. Every sample
+therefore pairs its command window with an idle window of the same length, and both
+estimators are the minimum over the samples, because both contaminants — a neighbour
+process execing, and the endpoint-security toll this machine charges every exec —
+only ever add.
+
+The minimum equals the true count exactly when some window caught the machine idle,
+so how often the idle windows came back empty is what says whether it did. That
+fraction is the per-window chance of a clean catch; over N samples the chance of
+having missed every one of them is ``(1 - fraction) ** N``, and a count is reported
+only once that is under one percent and the minimum has repeated. Sampling runs until
+it is, or until the budget expires — and then the run says it could not count rather
+than reporting a floor that is really an upper bound. Latency is reported either way:
+a busy machine inflates it, and the minimum says so by staying where it is.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from statistics import median
+
+from bench.counter import execs
+
+CONFIDENCE = 0.99
+CONFIRMATIONS = 3
+MINIMUM_SAMPLES = 30
+MAXIMUM_SAMPLES = 20_000
+BUDGET_S = 20.0
+
+
+@dataclass(frozen=True, slots=True)
+class Command:
+    argv: tuple[str, ...]
+    stdin: bytes = b""
+    env: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Window:
+    execs: int
+    ms: float
+
+
+@dataclass(frozen=True, slots=True)
+class Measurement:
+    label: str
+    active: tuple[Window, ...]
+    idle: tuple[Window, ...]
+
+    @property
+    def floor(self) -> int:
+        return min(window.execs for window in self.active)
+
+    @property
+    def confirmations(self) -> int:
+        return sum(window.execs == self.floor for window in self.active)
+
+    @property
+    def quiet_fraction(self) -> float:
+        return sum(window.execs == 0 for window in self.idle) / len(self.idle)
+
+    @property
+    def confidence(self) -> float:
+        return 1 - (1 - self.quiet_fraction) ** len(self.active)
+
+    @property
+    def counted(self) -> bool:
+        return self.confidence >= CONFIDENCE and self.confirmations >= CONFIRMATIONS
+
+    @property
+    def execs(self) -> int | None:
+        return self.floor if self.counted else None
+
+    @property
+    def ms_min(self) -> float:
+        return min(window.ms for window in self.active)
+
+    @property
+    def ms_median(self) -> float:
+        return median(window.ms for window in self.active)
+
+    @property
+    def ms_p90(self) -> float:
+        return percentile(sorted(window.ms for window in self.active), 0.9)
+
+
+class DispatchFailed(RuntimeError):
+    """A measured command exited nonzero, so the sample measures a failure."""
+
+
+def percentile(ordered: Sequence[float], fraction: float) -> float:
+    return ordered[min(len(ordered) - 1, int(fraction * len(ordered)))]
+
+
+def timed(action: Callable[[], object]) -> Window:
+    before = execs()
+    started = time.perf_counter_ns()
+    action()
+    elapsed = time.perf_counter_ns() - started
+    return Window(execs() - before, elapsed / 1e6)
+
+
+@contextmanager
+def spawner(command: Command) -> Iterator[Callable[[], None]]:
+    with tempfile.TemporaryFile() as stdin, open(os.devnull, "wb") as sink:
+        stdin.write(command.stdin)
+        stdin.flush()
+        yield lambda: spawn(command, stdin.fileno(), sink.fileno())
+
+
+def spawn(command: Command, stdin: int, sink: int) -> None:
+    os.lseek(stdin, 0, os.SEEK_SET)
+    pid = os.posix_spawn(
+        command.argv[0],
+        list(command.argv),
+        command.env if command.env is not None else os.environ,
+        file_actions=[
+            (os.POSIX_SPAWN_DUP2, stdin, 0),
+            (os.POSIX_SPAWN_DUP2, sink, 1),
+            (os.POSIX_SPAWN_DUP2, sink, 2),
+        ],
+    )
+    if code := os.waitstatus_to_exitcode(os.waitpid(pid, 0)[1]):
+        raise DispatchFailed(f"{command.argv[0]} exited {code}")
+
+
+def pair(run: Callable[[], None]) -> tuple[Window, Window]:
+    active = timed(run)
+    return active, timed(lambda: time.sleep(active.ms / 1000))
+
+
+def measure(
+    label: str,
+    command: Command,
+    *,
+    budget_s: float = BUDGET_S,
+    minimum_samples: int = MINIMUM_SAMPLES,
+    maximum_samples: int = MAXIMUM_SAMPLES,
+) -> Measurement:
+    """Sample ``command`` until its exec count is confidently counted, or until the budget runs out."""
+    deadline = time.monotonic() + budget_s
+    with spawner(command) as run:
+        run()
+        pairs = [pair(run) for _ in range(minimum_samples)]
+        while len(pairs) < maximum_samples and time.monotonic() < deadline:
+            if measurement(label, pairs).counted:
+                break
+            pairs.append(pair(run))
+    return measurement(label, pairs)
+
+
+def measurement(label: str, pairs: Sequence[tuple[Window, Window]]) -> Measurement:
+    return Measurement(label, tuple(active for active, _ in pairs), tuple(idle for _, idle in pairs))

--- a/bench/report.py
+++ b/bench/report.py
@@ -1,0 +1,82 @@
+"""The recorded baseline at ``bench/baseline.json`` — the numbers a later run is graded against.
+
+A baseline is data, not prose: a refactor that claims to drop an exec or shave a
+dispatch is checked by re-running ``python -m bench.cli run`` and diffing this file,
+not by remembering what the last measurement said. Latency travels with the machine
+facts that set its scale, because the same chain on the same machine costs what the
+endpoint-security exec toll of the hour charges it.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from bench.counter import endpoint_security_toll_us
+from bench.measure import Measurement
+
+BASELINE = Path(__file__).resolve().parent / "baseline.json"
+
+
+@dataclass(frozen=True, slots=True)
+class Record:
+    label: str
+    execs: int | None
+    exec_floor: int
+    confirmations: int
+    confidence: float
+    quiet_fraction: float
+    samples: int
+    ms_min: float
+    ms_median: float
+    ms_p90: float
+
+
+def record(measurement: Measurement) -> Record:
+    return Record(
+        label=measurement.label,
+        execs=measurement.execs,
+        exec_floor=measurement.floor,
+        confirmations=measurement.confirmations,
+        confidence=round(measurement.confidence, 4),
+        quiet_fraction=round(measurement.quiet_fraction, 4),
+        samples=len(measurement.active),
+        ms_min=round(measurement.ms_min, 2),
+        ms_median=round(measurement.ms_median, 2),
+        ms_p90=round(measurement.ms_p90, 2),
+    )
+
+
+def machine(build: str) -> dict[str, object]:
+    return {
+        "recorded": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "build": build,
+        "os": f"{platform.system()} {platform.release()}",
+        "arch": platform.machine(),
+        "endpoint_security_toll_us": round(endpoint_security_toll_us(), 1),
+    }
+
+
+def write_baseline(records: list[Record], *, build: str) -> Path:
+    BASELINE.write_text(
+        json.dumps({"machine": machine(build), "records": [asdict(r) for r in records]}, indent=2) + "\n"
+    )
+    return BASELINE
+
+
+def table(records: list[Record]) -> str:
+    rows = [
+        f"| {r.label} | {r.execs if r.execs is not None else f'>={r.exec_floor} (uncounted)'} | "
+        f"{r.ms_min} | {r.ms_median} | {r.ms_p90} | {r.samples} | {r.confidence} |"
+        for r in records
+    ]
+    return "\n".join(
+        [
+            "| scenario | execs/event | ms min | ms median | ms p90 | samples | confidence |",
+            "|---|---|---|---|---|---|---|",
+            *rows,
+        ]
+    )

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,53 @@
+"""The benchmark harness's own red line.
+
+A harness that miscounts would prove a refactor that never happened, so it is graded
+against exec counts verified by hand: ``posix_spawn`` of a binary is one ``execve``,
+``env`` adds one more for the command it replaces itself with, and a shell adds one
+for itself plus one for each command it runs. ``/bin/bash`` is the shell here rather
+than ``/bin/sh``, which costs two — Apple's ``sh`` re-execs itself into POSIX mode, so
+its count is right but no longer obvious, and a case nobody can verify by eye grades
+nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bench.measure import Command, Measurement, Window, measure
+
+BUDGET_S = 60.0
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        pytest.param(("/usr/bin/true",), 1, id="one-binary"),
+        pytest.param(("/usr/bin/env", "/usr/bin/true"), 2, id="env-replaces-itself"),
+        pytest.param(("/usr/bin/env", "/usr/bin/env", "/usr/bin/true"), 3, id="two-links"),
+        pytest.param(("/bin/bash", "-c", "/usr/bin/true"), 2, id="shell-and-one-child"),
+        pytest.param(("/bin/bash", "-c", "/usr/bin/true; /usr/bin/true"), 3, id="shell-and-two-children"),
+    ],
+)
+def test_harness_counts_execs_correctly(argv: tuple[str, ...], expected: int) -> None:
+    measurement = measure("counted", Command(argv), budget_s=BUDGET_S)
+    assert measurement.execs == expected, (
+        f"floor {measurement.floor} confirmed {measurement.confirmations}x at confidence "
+        f"{measurement.confidence:.3f} over {len(measurement.active)} samples"
+    )
+
+
+def test_harness_detects_a_planted_regression() -> None:
+    clean = measure("clean", Command(("/bin/bash", "-c", "/usr/bin/true")), budget_s=BUDGET_S)
+    extra = measure("extra-exec", Command(("/bin/bash", "-c", "/usr/bin/true; /usr/bin/true")), budget_s=BUDGET_S)
+    planted = measure("planted", Command(("/bin/bash", "-c", "/bin/sleep 0.005; /usr/bin/true")), budget_s=BUDGET_S)
+    assert clean.execs == 2
+    assert extra.execs == clean.execs + 1
+    assert planted.execs == clean.execs + 1
+    assert planted.ms_min - extra.ms_min >= 3
+
+
+def test_harness_refuses_a_count_no_quiet_window_confirmed() -> None:
+    floor = (Window(3, 1.0),) * 5
+    assert Measurement("never-quiet", floor, (Window(1, 1.0),) * 5).execs is None
+    assert Measurement("lone-floor", (Window(3, 1.0), *(Window(9, 1.0),) * 4), (Window(0, 1.0),) * 5).execs is None
+    assert Measurement("counted", floor, (Window(0, 1.0),) * 5).execs == 3

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -11,11 +11,16 @@ nothing.
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from bench.measure import Command, Measurement, Window, measure
 
 BUDGET_S = 60.0
+
+# The counter is a Darwin sysctl; there is no unprivileged equivalent to fall back to.
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS exec counter")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
capt-hook runs on every Claude Code lifecycle event across many concurrent sessions, and it has never had a latency benchmark. `stress/` covers the SessionEnd reviewer pipeline's correctness; every performance number in the project's history lives only in `CHANGELOG.md` prose. Upcoming work moves hot-path execs out of Python, and needs a recorded baseline to be graded against rather than a remembered one.

Adds `bench/` and `tests/test_bench.py`. No existing file changed.

## Counting execs without root

`sysctl security.mac.asp.stats.exec_hook_count` is a monotonic system-wide count of MAC exec-hook invocations — one per execve, readable unprivileged and in-process, so reading it costs no exec of its own. Verified 1:1 by hand: `/usr/bin/true` → 1, `env true` → 2, `env env true` → 3, `bash -c 'true'` → 2, `bash -c 'true; true'` → 3.

Everything else was tried and rejected with evidence:

| mechanism | why not |
|---|---|
| dtrace | `DTrace requires additional privileges`; root only |
| eslogger | `ES_NEW_CLIENT_RESULT_ERR_NOT_PRIVILEGED`; root only |
| process accounting | root only |
| `DYLD_INSERT_LIBRARIES` ledger | built and tested: blind to `/bin/sh` (platform binaries strip `DYLD_*`) and to the signed host (`flags=0x10000(runtime)`). Saw 1 of 4 execs — it would have silently undercounted |
| PATH shim farm | the chain execs absolute paths only (`os.execv(HOST)`, `Path: key.python`) |
| local capt-hookd + DYLD | `hostTrust()` gates the business lane on TeamID, so an ad-hoc build cannot reach the installed daemon |
| kqueue `NOTE_EXEC` | kevent OR-coalesces pending fflags; an N-exec chain can deliver one event. Lossy by construction |

## It refuses rather than guesses

The counter is system-wide, so a window also catches the machine's background execs — ambient ranged 68/s quiet to 325/s under load. Each sample pairs its command window with an idle window of equal length and takes `min(active)`. A count is reported only when the idle windows put the chance of having missed every quiet window under 1% **and** the minimum repeats at least 3 times. Otherwise `execs` is `null` and the record carries `exec_floor`, an upper bound.

Countability needs `ambient_rate × window < ~5`. A 65ms warm dispatch qualifies; a 650ms cold dispatch does not, at any load this machine reaches. Cold scenarios therefore record latency with a null count — see Limitations.

## Baseline (`bench/baseline.json`, Darwin 25.6.0 arm64, build 12.26.0)

| scenario | execs/event | ms min | ms median | ms p90 |
|---|---|---|---|---|
| chain-warm | **2** (conf 0.994, n=103) | 65.9 | 129.4 | 501.2 |
| chain-cold | null, floor ≥41 | 675.5 | 843.8 | 2258.8 |
| host-warm | **1** (conf 0.995) | 32.0 | 42.8 | 88.3 |
| host-cold | null, floor ≥14 | 633.0 | 913.2 | 5310.9 |
| interpreter-bare | 1 | 22.9 | 230.1 | 343.2 |
| interpreter-client | 1 | 40.5 | 87.5 | 254.5 |
| host-version | 1 | 5.4 | 6.8 | 8.5 |

A warm dispatch is 2 execs through the full chain and 1 through `capt-hookd` alone. Removing the Python interpreter from the dispatch path is therefore worth exactly **−1 exec/event and ~34ms** (`chain-warm − host-warm` on `ms_min`), corroborated independently by `interpreter-client` at 40.5ms.

Cold/warm control is free and touches nothing live: `ephemeralRoot()` retires a worker whose root is under `$TMPDIR` as soon as its dispatch finishes, so a scratch root there is cold every time and a root outside it is warm from the second dispatch.

## The harness is itself tested

A miscounting harness would "prove" the next PR falsely, so `tests/test_bench.py` grades both axes separately. The planted-regression test measures three commands — `clean` (2 execs), `extra-exec` (3, no sleep), `planted` (`sleep 0.005` + `true`, 3) — and asserts the extra exec against `clean` and the sleep against `extra-exec`, so neither assertion can be satisfied by the other injection.

Red-before-green, actually run:

1. Both detectors blinded (`timed()` returns `Window(0, 0.0)`) → 6 of 7 failed.
2. Clock blinded, counter live → both exec assertions passed and it failed exactly on the latency assertion, proving the sleep half is graded independently rather than riding on the exec half.
3. Restored → 7 passed.

## Limitations

- **No cold exec counts.** This mechanism cannot reach them at any load this machine sees. `cold = warm + 1` follows from `manager.go`, but it is a code-derived claim and is not recorded as measured data.
- **Subprocess execs inside the worker are not attributable.** The counter is system-wide, so work that moves `git`/`ps` execs out of the Python worker will not show up per-scenario here. Closing that needs a worker-spawn counter exposed over `status` and diffed by the harness — a daemon change, deliberately not made here.
- `/bin/sh -c ':'` costs 2 execs, not 1: Apple's `sh` re-execs itself, where `/bin/bash -c ':'` is 1. The counter is right; the tests use `bash` and say why.
- The harness resolves the deployed `hook` off PATH by matching its dist version to `capt-hookd version` and raises `DeploymentMissing` otherwise, since a worktree's editable install is version 0.0.0 and the daemon refuses it.
- Tests take ~6s quiet, ~60s under load (adaptive sampling), and fail loudly rather than skip when the machine is too busy to count.

https://claude.ai/code/session_012P3cgojXsje6g5RZXW2URE
