### PR TITLE
hookd: 🐛 name session capacity instead of blaming the install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/yasyf/captain-hook
 
 go 1.26.3
 
-require github.com/yasyf/daemonkit v0.23.0
+require github.com/yasyf/daemonkit v0.25.0
 
 require (
 	github.com/ebitengine/purego v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yasyf/daemonkit v0.23.0 h1:3ov00O4cEIbXAfj9h6uBpf8PMluGJcGGRvB5IVZhHXY=
 github.com/yasyf/daemonkit v0.23.0/go.mod h1:mnfLEwDeeyEmq7Dj+4/lJZ60sBcdI7GlWXLLuBSapyw=
+github.com/yasyf/daemonkit v0.25.0 h1:4akKBLvz/pzwiHmGVXrKfk2+nSelb9SDsw0Y0f0aWE8=
+github.com/yasyf/daemonkit v0.25.0/go.mod h1:3qcpiMyByFCbb9WcrzMYLcES/u/iUmE9UWBQb644ubo=
 go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
 go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/internal/hookd/client.go
+++ b/internal/hookd/client.go
@@ -46,13 +46,14 @@ func (c *Client) EnsureCurrent(ctx context.Context) error {
 	return health.exact()
 }
 
-// probeFailure names what the probe actually met, because the five outcomes
-// have five different next steps. ErrNotReady, ErrDraining, and ErrPeerGone are
-// one runtime mid-transition and answer again on the next event; a deadline is
-// a host that is there and slow; ErrUntrusted is a live peer that failed the
-// signed-host requirement, which reinstalling fixes and waiting does not; and
-// ErrNoVerifier is a machine that cannot answer the question at all. Only what
-// is left is a host that is not installed.
+// probeFailure names what the probe actually met, because the outcomes have
+// different next steps. ErrNotReady, ErrDraining, and ErrPeerGone are one
+// runtime mid-transition and answer again on the next event; ErrSessionCapacity
+// is a healthy host with every session slot taken, which waiting also fixes; a
+// deadline is a host that is there and slow; ErrUntrusted is a live peer that
+// failed the signed-host requirement, which reinstalling fixes and waiting does
+// not; and ErrNoVerifier is a machine that cannot answer the question at all.
+// Only what is left is a host that is not installed.
 func probeFailure(err error) error {
 	switch {
 	case errors.Is(err, daemonkit.ErrNotReady), errors.Is(err, daemonkit.ErrDraining),
@@ -60,6 +61,11 @@ func probeFailure(err error) error {
 		return fmt.Errorf(
 			"captain: signed host is between generations — starting, draining, or restarting — "+
 				"and hooks retry on the next event: %w", err,
+		)
+	case errors.Is(err, daemonkit.ErrSessionCapacity):
+		return fmt.Errorf(
+			"captain: signed host is serving its session ceiling and has no slot for this hook; "+
+				"it is installed and healthy, and hooks retry on the next event: %w", err,
 		)
 	case errors.Is(err, os.ErrDeadlineExceeded), errors.Is(err, context.DeadlineExceeded):
 		return fmt.Errorf(

--- a/internal/hookd/client_test.go
+++ b/internal/hookd/client_test.go
@@ -55,6 +55,11 @@ func TestProbeFailureNamesTheOutcomeItMet(t *testing.T) {
 			transition, []string{absentMessage, installRemedy, "machine load"},
 		},
 		{
+			"every session slot taken", fmt.Errorf("captain: attach: %w", daemonkit.ErrSessionCapacity),
+			[]string{"session ceiling", "installed and healthy", "retry on the next event"},
+			[]string{absentMessage, installRemedy, "machine load"},
+		},
+		{
 			"untrusted server", fmt.Errorf("captain: attach: %w", daemonkit.ErrUntrusted),
 			[]string{"is not the signed capt-hookd", "reinstall the helper"},
 			[]string{absentMessage, "retry on the next event", "machine load"},


### PR DESCRIPTION
Picks up daemonkit v0.25.0 and stops reporting a healthy, saturated host as an uninstalled one.

## The message this replaces

Capacity exhaustion reached `probeFailure`'s catch-all, so the operator was told to reinstall a host that was installed, healthy, and simply busy:

```
captain: signed host is not installed and ready; run `capt-hook helper install`:
  captain: attach: wire: session capacity exhausted
```

`capt-hook helper install` fixes nothing here and the condition clears on its own. `ErrSessionCapacity` now has its own arm, naming the ceiling and saying the host is fine:

```
captain: signed host is serving its session ceiling and has no slot for this hook;
  it is installed and healthy, and hooks retry on the next event: ...
```

The new row in `TestProbeFailureNamesTheOutcomeItMet` asserts the message contains "session ceiling" and "installed and healthy", and — the point of the change — that it does **not** contain the absent-host text or the install remedy. Removing the arm reproduces the string above verbatim:

```
client_test.go:89: message is missing "session ceiling":
captain: signed host is not installed and ready; run `capt-hook helper install`: ...
```

## Session reclaim arrives with the bump

daemonkit v0.25.0 carries `Daemon.Idle`: a session whose peer sends no frame and holds no in-flight request has its lane slot reclaimed. Before it, a peer that neither sent nor closed — suspended, asleep, or behind a socket the kernel never tears down — held its slot until the daemon restarted, which is how the ceiling was reached in the first place.

`hostDaemon()` deliberately does not set `Idle`. Zero means the documented 15m default, and restating a default is a line that can drift from it. 15m is the right order for this host: sessions here are hook dispatches lasting seconds, plus the helper app, so the timer will rarely fire and a client it does evict redials — `Client.Business()` is not a single-session lane, so `retire` nils the session and the next call re-attaches.

The ceiling itself went 64 → 256 in #38.

## Verification

`go build ./...`, `go test -race -count=1 ./internal/hookd/` green against v0.25.0. The suite also ran green against daemonkit `main` before the tag existed, via a throwaway `go.work` overlay — fleet-build only proves the tree compiles, so that check was worth making separately.

v0.25.0 carries breaking removals (`launchd.RemoveUnmarked`, `launchd.SessionType` and friends). Neither appears anywhere in captain-hook's production code; the only mention is one test asserting a rendered plist does *not* contain `LimitLoadToSessionType`, which still holds.

https://claude.ai/code/session_012P3cgojXsje6g5RZXW2URE
